### PR TITLE
Move R part of generateModuleInstallingR() to common

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# History files
+.Rhistory
+.Rapp.history
+
+# Session Data files
+.RData
+
+# User-specific files
+.Ruserdata
+
+# Example code in package build process
+*-Ex.R
+
+# Output files from R CMD build
+/*.tar.gz
+
+# Output files from R CMD check
+/*.Rcheck/
+
+# RStudio files
+.Rproj.user/
+
+# produced vignettes
+vignettes/*.html
+vignettes/*.pdf
+
+# OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
+.httr-oauth
+
+# knitr and R markdown default cache directories
+*_cache/
+/cache/
+
+# Temporary files created by R markdown
+*.utf8.md
+*.knit.md
+
+# R Environment Variables
+.Renviron
+
+# pkgdown site
+docs/
+
+# translation temp files
+po/*~
+
+# OSX files
+*.DS_Store
+Thumbs.db

--- a/jaspBase.Rproj
+++ b/jaspBase.Rproj
@@ -1,0 +1,20 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
Also adds a function that takes a description file and spits out the dependencies.

Ok so basically I just moved the R part from the cpp function `generateModuleInstallingR()`, but I was a little confused at its setup (and I'm curious if some of it could be simplified by overwriting system2, see [this](https://r.789695.n4.nabble.com/Capture-output-of-install-packages-pipe-system2-td4676754.html) and [this](https://stackoverflow.com/questions/12416076/suppress-install-outputs-in-r)). But I didn't want to go too deep into it. If this is not what you had intended, we can zoom @JorisGoosen.

Mapping of R to C++ args:
```
modulePkg      = _modulePackage
libPathsToUse  = getLibPathsToUse()
moduleLibrary  = moduleRLibrary().toStdString()
repos          = Settings::value(Settings::CRAN_REPO_URL).toString().toStdString()
onlyModPkg     = onlyModPkg
```

Possible issues
1. jaspModules can exist in multiple folders (if you `install_deps` and one of the deps is a jaspModule it will also install that, unless it's found in one of the other libraries)
2. Unless the environment variable `GITHUB_PAT` is set, the `remotes` package uses a default public Github PAT which has a limit of 60 queries per IP address per hour.

See https://github.com/jasp-stats/INTERNAL-jasp/issues/1014#issuecomment-673405667