### PR TITLE
Add the jaspResults "gridGraphics" dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,11 +8,11 @@ Description: Package contains the JASP Bayesian and Frequentist analyses.
     See <https://jasp-stats.org> for more details.
 License: GPL2+
 Imports: 
-	modules,
-	pkgbuild,
-	renv,
-	remotes, 
-	jsonlite,
-	rjson,
-	Rcpp
-
+  gridGraphics,
+  modules,
+  pkgbuild,
+  renv,
+  remotes, 
+  jsonlite,
+  rjson,
+  Rcpp


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1268

@vandenman: it might be better to put the jaspResults dependencies here considering jaspBase is a common dependency of all modules