### PR TITLE
Reenable save as svg and improve error message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,5 +28,6 @@ Imports:
   renv,
   rjson,
   rvg,
+  svglite,
   systemfonts,
   withr

--- a/R/common.R
+++ b/R/common.R
@@ -690,9 +690,18 @@ saveImage <- function(plotName, format, height, width)
           type     = type
         )
 
+      } else if (format == "svg") {
+
+        # convert width & height from pixels to inches. ppi = pixels per inch. 72 is a magic number inherited from the past.
+        # originally, this number was 96 but svglite scales this by (72/96 = 0.75). 0.75 * 96 = 72.
+        # for reference see https://cran.r-project.org/web/packages/svglite/vignettes/scaling.html
+        width  <- width  / 72
+        height <- height / 72
+        svglite::svglite(file = relativePath, width = width, height = height)
+
       } else { # add optional other formats here in "else if"-statements
 
-        stop("Format incorrectly specified")
+        stop("Unknown image format '", format, "'", domain = NA)
 
       }
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1390

The changes to `saveImage` are identical to those in https://github.com/jasp-stats/jasp-desktop/pull/4215, but it got lost when we split off jaspBase into a module. For this to work, we also need `svglite` as a dependency and that's why I assigned @JorisGoosen as a reviewer, who can hopefully tell me what I need to do to ensure that the buildbot/ nightlies don't break.

In addition, the error message about invalid format now says what format is actually invalid, and `domain = NA` avoids this from being ever translated.