### PR TITLE
 Only reuse plot info when a plot was resized

### DIFF
--- a/R/common.R
+++ b/R/common.R
@@ -863,6 +863,8 @@ editImage <- function(name, optionsJson) {
         # ensures the JSON response matches the plot
         width  <- oldWidth
         height <- oldHeight
+      } else {
+        jaspPlotCPP$resizedByUser <- TRUE
       }
 
     } else if (type == "interactive" && ggplot2::is.ggplot(plot)) {


### PR DESCRIPTION
Prerequisite for https://github.com/jasp-stats/jaspResults/pull/3