### PR TITLE
deprecate .v() and .unv() explicitly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ Imports:
   gridExtra,
   gridGraphics,
   jsonlite,
+  lifecycle,
   methods,
   modules,
   officer,

--- a/R/base64.R
+++ b/R/base64.R
@@ -16,10 +16,26 @@
 #
 
 #' @export
-.v <- function(x, ...) { x }
+.v <- function(x, ...) {
+  lifecycle::deprecate_warn(
+    "0.15",
+    "jaspBase::.v()",
+    "jaspResults::encodeColNames()",
+    details = "JASP handles encoding automatically. If you are sure you want to encode column names manually, use `jaspResults::encodeColNames()`. The call to `.v()` has no effect anymore and should be removed."
+  )
+  x
+}
 
 #' @export
-.unv <- function(x, ...) { x }
+.unv <- function(x, ...) {
+  lifecycle::deprecate_warn(
+    "0.15",
+    "jaspBase::.unv()",
+    "jaspResults::decodeColNames()",
+    details = "JASP handles decoding automatically. If you are sure you want to decode column names manually, use `jaspResults::decodeColNames()`. The call to `.unv()` has no effect anymore and should be removed."
+  )
+  x
+}
 
 #' @export
 interactionSymbol <- "\u2009\u273B\u2009"


### PR DESCRIPTION
Despite we deprecated this a while ago and removed it from the majority of our code, I still see new JASP programmers attempt to use those functions sometimes. So I figured it could be nice to be explicit about this, instead of having to repeatedly ask to remove this during code review (we could do this more systematically in general whenever we deprecate a function/argument). Since `lifecycle::deprecate_warn()` generates the warning only once every 8 hours, this will not clog the output of the unit tests for analyses that still use these functions.