### PR TITLE
`.setSeedJASP`: avoid calling `&&` with length > 1

### DIFF
--- a/R/common.R
+++ b/R/common.R
@@ -572,7 +572,7 @@ jaspResultsStrings <- function() {
 #' @export
 .setSeedJASP <- function(options) {
 
-  if (is.list(options) && c("setSeed", "seed") %in% names(options)) {
+  if (is.list(options) && all(c("setSeed", "seed") %in% names(options))) {
     if (isTRUE(options[["setSeed"]]))
       set.seed(options[["seed"]])
   } else {


### PR DESCRIPTION
This line

https://github.com/jasp-stats/jaspBase/blob/026404c45ff21801e14f8e8175d972be0ac8e8f8/R/common.R#L575

[will break in R > 4.2.0](https://developer.r-project.org/blosxom.cgi/R-devel/NEWS/2022/04/05#n2022-04-05) because it results in

```
if (bool && c(bool, bool))
```
so I added an `all`.
