### PR TITLE
Restore options after running an analysis

### DIFF
--- a/R/common.R
+++ b/R/common.R
@@ -101,8 +101,9 @@ runJaspResults <- function(name, title, dataKey, options, stateKey, functionCall
   }
 
   registerFonts()
-  oldGraphOptions <- jaspGraphs::graphOptions()
-  on.exit(jaspGraphs::graphOptions(oldGraphOptions), add = TRUE)
+
+  # resets jaspGraphs::graphOptions & options after this function finishes
+  setOptionsCleanupHook()
 
   analysisResult <-
     tryCatch(

--- a/R/utility.R
+++ b/R/utility.R
@@ -15,9 +15,9 @@ getOS <- function() {
 }
 
 restoreOptions <- function(oldOptions) {
-  # avoid contaminating options
 
-  # NOTE: options(oldOptions) is insufficient (like withr does), because this does not remove any options that were set before
+  # NOTE: `options(oldOptions)`, like withr does, is insufficient because this does not remove any options that were set before
+
   # for example,
   # oldOptions <- options()
   # options("a")

--- a/R/utility.R
+++ b/R/utility.R
@@ -1,17 +1,51 @@
 #' @export
-getOS <- function()
-{
+getOS <- function() {
   os <- NULL
   if (!is.null(Sys.info())) {
     os <- Sys.info()["sysname"]
     if (os == "Darwin")
       os <- "osx"
-  }
-  else {
+  } else {
     if (grepl("^darwin", R.version$os))
       os <- "osx"
     if (grepl("linux-gnu", R.version$os))
       os <- "linux"
   }
   return(tolower(os))
+}
+
+restoreOptions <- function(oldOptions) {
+  # avoid contaminating options
+
+  # NOTE: options(oldOptions) is insufficient (like withr does), because this does not remove any options that were set before
+  # for example,
+  # oldOptions <- options()
+  # options("a")
+  # $a
+  # NULL
+  # options("a" = 1)
+  # options("a")
+  # $a
+  # [1] 1
+  # options(oldOptions)
+  # options("a") # still there!
+  # $a
+  # [1] 1
+
+  newOptions <- options()
+  oldOptions[setdiff(names(newOptions), names(oldOptions))] <- list(NULL)
+  options(oldOptions)
+
+}
+
+setOptionsCleanupHook <- function() {
+
+  oldGraphOptions <- jaspGraphs::graphOptions()
+  oldOptions <- options()
+
+  withr::defer({
+    restoreOptions(oldOptions)
+    jaspGraphs::graphOptions(oldGraphOptions)
+  }, envir = parent.frame(2))
+
 }


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1833

@JorisGoosen about [this comment](https://github.com/jasp-stats/INTERNAL-jasp/issues/1833#issuecomment-1212037257)

> This could be combined with `jaspBase:::.cleanEngineMemory()` right?

I'd propose the opposite :smile:. `.cleanEngineMemory()` can be called from `setOptionsCleanupHook`. That way, we'll also ensure in the future that people running syntax won't get their global environment polluted by some weird jasp/ R package function. Also, the less C++ <-> R back and forth interaction, the better IMO.

While the changes here are probably quite harmless, I nevertheless think it's best to merge this after 0.16.4 since this only cleans up some code and doesn't fix anything at the moment (hence I assigned it to 0.17). After this PR is merged, https://github.com/jasp-stats/jaspAnova/pull/156 should probably be reverted.