### PR TITLE
extract whole error message

### DIFF
--- a/R/common.R
+++ b/R/common.R
@@ -536,10 +536,8 @@ jaspResultsStrings <- function() {
 
 #' @export
 .extractErrorMessage <- function(error) {
-
-  split <- base::strsplit(as.character(error), ":")[[1]]
-  last <- split[[length(split)]]
-  trimws(last)
+  msg <- attr(error, "condition")$message
+  trimws(msg)
 }
 
 #' @export

--- a/R/common.R
+++ b/R/common.R
@@ -546,7 +546,7 @@ jaspResultsStrings <- function() {
     last <- split[[length(split)]]
     return(trimws(last))
   } else {
-    stop("Do not know what to do with an object of class `", class(error)[1], "`; The class of the `error` object should be `try-error` or `character`!" )
+    stop("Do not know what to do with an object of class `", class(error)[1], "`; The class of the `error` object should be `try-error` or `character`!", domain = NA)
   }
 }
 

--- a/R/common.R
+++ b/R/common.R
@@ -536,8 +536,18 @@ jaspResultsStrings <- function() {
 
 #' @export
 .extractErrorMessage <- function(error) {
-  msg <- attr(error, "condition")$message
-  trimws(msg)
+  stopifnot(length(error) == 1)
+
+  if (isTryError(error)) {
+    msg <- attr(error, "condition")$message
+    return(trimws(msg))
+  } else if (is.character(error)){
+    split <- base::strsplit(error, ":")[[1]]
+    last <- split[[length(split)]]
+    return(trimws(last))
+  } else {
+    stop("Do not know what to do with an object of class `", class(error)[1], "`; The class of the `error` object should be `try-error` or `character`!" )
+  }
 }
 
 #' @export


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-test-release/issues/1960

The previous method attempts to extract the error message by converting the error object into a character and parsing the string. This works fine as long as the error message itself does not contain symbol `:`, e.g.

```r
foo <- function() { stop("No components with an eigenvalue > 1.2. Maximum observed eigenvalue: 1.059") }
x <- try(foo())
```

Here we just extract the message directly from the object's attributes without relying on character parsing.

old implementation:

```r
.extractErrorMessage(x)
# [1] "1.059"
```

new implementation:

```r
.extractErrorMessage(x)
# [1] "No components with an eigenvalue > 1.2. Maximum observed eigenvalue: 1.059"
```