### PR TITLE
fixing computed column by passing pointers, and more

### DIFF
--- a/configure
+++ b/configure
@@ -110,6 +110,5 @@ if [ "${JASP_R_INTERFACE_LIBRARY}" != "" ]; then
 fi
 
 sed -e "s|@cppflags@|${PKG_CXXFLAGS}|" -e "s|@src_sources@|${SRC_SOURCES}|" -e "s|@jaspColumnEncoder_sources@|${JASPCOLUMNENCODER_SOURCES}|" src/Makevars.in > src/Makevars
-#sed -e "s|@cppflags@|${PKG_CXXFLAGS_EXPANDED}|" -e "s|@src_sources@|${SRC_SOURCES}|" -e "s|@jaspColumnEncoder_sources@|${JASPCOLUMNENCODER_SOURCES}|" -e "s|@jasp_r_interface@|${JASP_R_INTERFACE_LIBRARY_VALUE}|" src/Makevars.in > src/Makevars
 
 exit 0

--- a/configure
+++ b/configure
@@ -104,6 +104,15 @@ fi
 SRC_SOURCES="$(cd src/ && ls *.cpp | tr '\n' ' ')"
 JASPCOLUMNENCODER_SOURCES="$(cd src/ && ls ${JASPCOLUMNENCODER_DIR}/*.cpp | tr '\n' ' ')"
 
+#if [ "${JASP_R_INTERFACE_LIBRARY}" ]; then
+#	JASP_R_INTERFACE_LIBRARY_VALUE="-DJASP_R_INTERFACE_LIBRARY=1 -I${INCLUDE_DIR}/../../R-Interface -I/home/don/github/build-jasp-desktop-Desktop_Qt_6_3_1_GCC_64bit-Debug/R/library/RInside/include/"
+#else
+#	JASP_R_INTERFACE_LIBRARY_VALUE="-DJASP_R_INTERFACE_LIBRARY=0"
+#fi
+
+echo "JASP_R_INTERFACE_LIBRARY=${JASP_R_INTERFACE_LIBRARY_VALUE}"
+
 sed -e "s|@cppflags@|${PKG_CXXFLAGS}|" -e "s|@src_sources@|${SRC_SOURCES}|" -e "s|@jaspColumnEncoder_sources@|${JASPCOLUMNENCODER_SOURCES}|" src/Makevars.in > src/Makevars
+#sed -e "s|@cppflags@|${PKG_CXXFLAGS}|" -e "s|@src_sources@|${SRC_SOURCES}|" -e "s|@jaspColumnEncoder_sources@|${JASPCOLUMNENCODER_SOURCES}|" -e "s|@jasp_r_interface@|${JASP_R_INTERFACE_LIBRARY_VALUE}|" src/Makevars.in > src/Makevars
 
 exit 0

--- a/configure
+++ b/configure
@@ -104,15 +104,12 @@ fi
 SRC_SOURCES="$(cd src/ && ls *.cpp | tr '\n' ' ')"
 JASPCOLUMNENCODER_SOURCES="$(cd src/ && ls ${JASPCOLUMNENCODER_DIR}/*.cpp | tr '\n' ' ')"
 
-#if [ "${JASP_R_INTERFACE_LIBRARY}" ]; then
-#	JASP_R_INTERFACE_LIBRARY_VALUE="-DJASP_R_INTERFACE_LIBRARY=1 -I${INCLUDE_DIR}/../../R-Interface -I/home/don/github/build-jasp-desktop-Desktop_Qt_6_3_1_GCC_64bit-Debug/R/library/RInside/include/"
-#else
-#	JASP_R_INTERFACE_LIBRARY_VALUE="-DJASP_R_INTERFACE_LIBRARY=0"
-#fi
-
-echo "JASP_R_INTERFACE_LIBRARY=${JASP_R_INTERFACE_LIBRARY_VALUE}"
+#add the define if JASP_R_INTERFACE_LIBRARY env var says anything at all
+if [ "${JASP_R_INTERFACE_LIBRARY}" != "" ]; then
+	PKG_CXXFLAGS=-DJASP_R_INTERFACE_LIBRARY\ ${PKG_CXXFLAGS}
+fi
 
 sed -e "s|@cppflags@|${PKG_CXXFLAGS}|" -e "s|@src_sources@|${SRC_SOURCES}|" -e "s|@jaspColumnEncoder_sources@|${JASPCOLUMNENCODER_SOURCES}|" src/Makevars.in > src/Makevars
-#sed -e "s|@cppflags@|${PKG_CXXFLAGS}|" -e "s|@src_sources@|${SRC_SOURCES}|" -e "s|@jaspColumnEncoder_sources@|${JASPCOLUMNENCODER_SOURCES}|" -e "s|@jasp_r_interface@|${JASP_R_INTERFACE_LIBRARY_VALUE}|" src/Makevars.in > src/Makevars
+#sed -e "s|@cppflags@|${PKG_CXXFLAGS_EXPANDED}|" -e "s|@src_sources@|${SRC_SOURCES}|" -e "s|@jaspColumnEncoder_sources@|${JASPCOLUMNENCODER_SOURCES}|" -e "s|@jasp_r_interface@|${JASP_R_INTERFACE_LIBRARY_VALUE}|" src/Makevars.in > src/Makevars
 
 exit 0

--- a/src/jaspColumn.cpp
+++ b/src/jaspColumn.cpp
@@ -1,69 +1,49 @@
-
 #include "jaspColumn.h"
 
-setColumnDataFuncDef	jaspColumn::_jaspRCPP_setColumnDataAsScaleFunc				= nullptr;
-setColumnDataFuncDef	jaspColumn::_jaspRCPP_setColumnDataAsOrdinalFunc			= nullptr;
-setColumnDataFuncDef	jaspColumn::_jaspRCPP_setColumnDataAsNominalFunc			= nullptr;
-setColumnDataFuncDef	jaspColumn::_jaspRCPP_setColumnDataAsNominalTextFunc		= nullptr;
-getColumnTypeFuncDef	jaspColumn::_jaspRCPP_getColumnTypeFunc						= nullptr;
+getColumnTypeFuncDef	jaspColumn::_getColumnTypeFunc					= nullptr;
+setColumnDataFuncDef	jaspColumn::_setColumnDataAsScaleFunc			= nullptr;
+setColumnDataFuncDef	jaspColumn::_setColumnDataAsOrdinalFunc			= nullptr;
+setColumnDataFuncDef	jaspColumn::_setColumnDataAsNominalFunc			= nullptr;
+setColumnDataFuncDef	jaspColumn::_setColumnDataAsNominalTextFunc		= nullptr;
 
-void jaspColumn::set_jaspRCPP_setColumnDataAsScaleFunc(setColumnDataFuncDef func)
+void jaspColumn::setColumnFuncs(colDataF scalar, colDataF ordinal, colDataF nominal, colDataF nominalText, colgetTF colType)
 {
-	_jaspRCPP_setColumnDataAsScaleFunc = func;
-}
-void jaspColumn::set_jaspRCPP_setColumnDataAsScaleFuncXPtr(Rcpp::XPtr<setColumnDataFuncDef> func)
-{
-	set_jaspRCPP_setColumnDataAsScaleFunc(*func);
-}
-
-void jaspColumn::set_jaspRCPP_setColumnDataAsOrdinalFunc(setColumnDataFuncDef func)
-{
-	_jaspRCPP_setColumnDataAsScaleFunc = func;
-}
-void jaspColumn::set_jaspRCPP_setColumnDataAsOrdinalFuncXPtr(Rcpp::XPtr<setColumnDataFuncDef> func)
-{
-	set_jaspRCPP_setColumnDataAsOrdinalFunc(*func);
+	_getColumnTypeFunc 				= * colType;
+	_setColumnDataAsScaleFunc 		= * scalar;
+	_setColumnDataAsOrdinalFunc 	= * ordinal;
+	_setColumnDataAsNominalFunc 	= * nominal;
+	_setColumnDataAsNominalTextFunc = * nominalText;
 }
 
-void jaspColumn::set_jaspRCPP_setColumnDataAsNominalFunc(setColumnDataFuncDef func)
-{
-	_jaspRCPP_setColumnDataAsNominalFunc = func;
-}
-void jaspColumn::set_jaspRCPP_setColumnDataAsNominalFuncXPtr(Rcpp::XPtr<setColumnDataFuncDef> func)
-{
-	set_jaspRCPP_setColumnDataAsNominalFunc(*func);
-}
+#define SET_COLUMN_DATA_BASE(FUNC)									\
+{																	\
+	if ( FUNC == nullptr ) 											\
+	{																\
+		jaspPrint("jaspColumn does nothing in R stand-alone!"); 	\
+		return false;												\
+	} 																\
+	else 															\
+		return (*FUNC)(columnName, data);							\
+}																	\
 
-void jaspColumn::set_jaspRCPP_setColumnDataAsNominalTextFunc(setColumnDataFuncDef func)
-{
-	_jaspRCPP_setColumnDataAsNominalTextFunc = func;
-}
-void jaspColumn::set_jaspRCPP_setColumnDataAsNominalTextFuncXPtr(Rcpp::XPtr<setColumnDataFuncDef> func)
-{
-	set_jaspRCPP_setColumnDataAsNominalTextFunc(*func);
-}
+bool	jaspColumn::setColumnDataAsScale(		const std::string & columnName, Rcpp::RObject data) SET_COLUMN_DATA_BASE(_setColumnDataAsScaleFunc)
+bool	jaspColumn::setColumnDataAsOrdinal(		const std::string & columnName, Rcpp::RObject data) SET_COLUMN_DATA_BASE(_setColumnDataAsOrdinalFunc)
+bool	jaspColumn::setColumnDataAsNominal(		const std::string & columnName, Rcpp::RObject data) SET_COLUMN_DATA_BASE(_setColumnDataAsNominalFunc)
+bool	jaspColumn::setColumnDataAsNominalText(	const std::string & columnName, Rcpp::RObject data) SET_COLUMN_DATA_BASE(_setColumnDataAsNominalTextFunc)
 
-void jaspColumn::set_jaspRCPP_getColumnTypeFunc(getColumnTypeFuncDef func)
-{
-	_jaspRCPP_getColumnTypeFunc = func;
+columnType jaspColumn::getColumnType(const std::string & columnName)
+{ 
+	if(!_getColumnTypeFunc) 
+		return columnType::unknown;
+	else
+		return (*_getColumnTypeFunc)(columnName); 
 }
-void jaspColumn::set_jaspRCPP_getColumnTypeFuncXPtr(Rcpp::XPtr<getColumnTypeFuncDef> func)
-{
-	set_jaspRCPP_getColumnTypeFunc(*func);
-}
-
-bool	jaspColumn::jaspRCPP_setColumnDataAsScale(			std::string columnName, Rcpp::RObject scalarData) { if (_jaspRCPP_setColumnDataAsScaleFunc			== nullptr) { jaspPrint("jaspColumn does nothing in R stand-alone!"); return false;} else return (*_jaspRCPP_setColumnDataAsScaleFunc)(columnName, scalarData); }
-bool	jaspColumn::jaspRCPP_setColumnDataAsOrdinal(		std::string columnName, Rcpp::RObject scalarData) { if (_jaspRCPP_setColumnDataAsOrdinalFunc		== nullptr) { jaspPrint("jaspColumn does nothing in R stand-alone!"); return false;} else return (*_jaspRCPP_setColumnDataAsOrdinalFunc)(columnName, scalarData); }
-bool	jaspColumn::jaspRCPP_setColumnDataAsNominal(		std::string columnName, Rcpp::RObject scalarData) { if (_jaspRCPP_setColumnDataAsNominalFunc		== nullptr) { jaspPrint("jaspColumn does nothing in R stand-alone!"); return false;} else return (*_jaspRCPP_setColumnDataAsNominalFunc)(columnName, scalarData); }
-bool	jaspColumn::jaspRCPP_setColumnDataAsNominalText(	std::string columnName, Rcpp::RObject scalarData) { if (_jaspRCPP_setColumnDataAsNominalTextFunc	== nullptr) { jaspPrint("jaspColumn does nothing in R stand-alone!"); return false;} else return (*_jaspRCPP_setColumnDataAsNominalTextFunc)(columnName, scalarData); }
-
-columnType jaspColumn::jaspRCPP_getColumnType(std::string columnName) { return (_jaspRCPP_getColumnTypeFunc == nullptr) ? columnType::unknown : (*_jaspRCPP_getColumnTypeFunc)(columnName); }
 
 jaspColumn::jaspColumn(std::string columnName)
 	: jaspObject(jaspObjectType::column, "jaspColumn for " + columnName)
 	, _columnName(columnName)
 {
-	switch(jaspRCPP_getColumnType(columnName))
+	switch(getColumnType(columnName))
 	{
 	case columnType::scale:			_columnType = jaspColumnType::scale;		break;
 	case columnType::ordinal:		_columnType = jaspColumnType::ordinal;		break;
@@ -104,7 +84,7 @@ std::string jaspColumn::dataToString(std::string prefix) const
 
 void jaspColumn::setScale(Rcpp::RObject scalarData)
 {
-	_dataChanged	= jaspRCPP_setColumnDataAsScale(_columnName, scalarData);
+	_dataChanged	= setColumnDataAsScale(_columnName, scalarData);
 	_typeChanged	= _columnType != jaspColumnType::scale;
 	_columnType		= jaspColumnType::scale;
 
@@ -114,7 +94,7 @@ void jaspColumn::setScale(Rcpp::RObject scalarData)
 
 void jaspColumn::setOrdinal(Rcpp::RObject ordinalData)
 {
-	_dataChanged	= jaspRCPP_setColumnDataAsOrdinal(_columnName, ordinalData);
+	_dataChanged	= setColumnDataAsOrdinal(_columnName, ordinalData);
 	_typeChanged	= _columnType != jaspColumnType::ordinal;
 	_columnType		= jaspColumnType::ordinal;
 
@@ -124,7 +104,7 @@ void jaspColumn::setOrdinal(Rcpp::RObject ordinalData)
 
 void jaspColumn::setNominal(Rcpp::RObject nominalData)
 {
-	_dataChanged	= jaspRCPP_setColumnDataAsNominal(_columnName, nominalData);
+	_dataChanged	= setColumnDataAsNominal(_columnName, nominalData);
 	_typeChanged	= _columnType != jaspColumnType::nominal;
 	_columnType		= jaspColumnType::nominal;
 
@@ -134,7 +114,7 @@ void jaspColumn::setNominal(Rcpp::RObject nominalData)
 
 void jaspColumn::setNominalText(Rcpp::RObject nominalData)
 {
-	_dataChanged	= jaspRCPP_setColumnDataAsNominalText(_columnName, nominalData);
+	_dataChanged	= setColumnDataAsNominalText(_columnName, nominalData);
 	_typeChanged	= _columnType != jaspColumnType::nominalText;
 	_columnType		= jaspColumnType::nominalText;
 

--- a/src/jaspColumn.cpp
+++ b/src/jaspColumn.cpp
@@ -1,22 +1,63 @@
 
 #include "jaspColumn.h"
 
-#ifdef JASP_R_INTERFACE_LIBRARY
-#include "jasprcpp.h"
-#else
+setColumnDataFuncDef	jaspColumn::_jaspRCPP_setColumnDataAsScaleFunc				= nullptr;
+setColumnDataFuncDef	jaspColumn::_jaspRCPP_setColumnDataAsOrdinalFunc			= nullptr;
+setColumnDataFuncDef	jaspColumn::_jaspRCPP_setColumnDataAsNominalFunc			= nullptr;
+setColumnDataFuncDef	jaspColumn::_jaspRCPP_setColumnDataAsNominalTextFunc		= nullptr;
+getColumnTypeFuncDef	jaspColumn::_jaspRCPP_getColumnTypeFunc						= nullptr;
 
-enum ColumnType { ColumnTypeUnknown = 0, ColumnTypeNominal = 1, ColumnTypeNominalText = 2, ColumnTypeOrdinal = 4, ColumnTypeScale = 8 };
-bool	jaspRCPP_setColumnDataAsScale(			std::string, Rcpp::RObject) { jaspPrint("jaspColumn does nothing in R stand-alone!"); return false; };
-bool	jaspRCPP_setColumnDataAsOrdinal(		std::string, Rcpp::RObject) { jaspPrint("jaspColumn does nothing in R stand-alone!"); return false; };
-bool	jaspRCPP_setColumnDataAsNominal(		std::string, Rcpp::RObject) { jaspPrint("jaspColumn does nothing in R stand-alone!"); return false; };
-bool	jaspRCPP_setColumnDataAsNominalText(	std::string, Rcpp::RObject) { jaspPrint("jaspColumn does nothing in R stand-alone!"); return false; };
+void jaspColumn::set_jaspRCPP_setColumnDataAsScaleFunc(setColumnDataFuncDef func)
+{
+	_jaspRCPP_setColumnDataAsScaleFunc = func;
+}
+void jaspColumn::set_jaspRCPP_setColumnDataAsScaleFuncXPtr(Rcpp::XPtr<setColumnDataFuncDef> func)
+{
+	set_jaspRCPP_setColumnDataAsScaleFunc(*func);
+}
 
-#define ENUM_DECLARATION_CPP
-#include "columntype.h"
+void jaspColumn::set_jaspRCPP_setColumnDataAsOrdinalFunc(setColumnDataFuncDef func)
+{
+	_jaspRCPP_setColumnDataAsScaleFunc = func;
+}
+void jaspColumn::set_jaspRCPP_setColumnDataAsOrdinalFuncXPtr(Rcpp::XPtr<setColumnDataFuncDef> func)
+{
+	set_jaspRCPP_setColumnDataAsOrdinalFunc(*func);
+}
 
-columnType jaspRCPP_getColumnType(std::string columnName) { return columnType::unknown; }
+void jaspColumn::set_jaspRCPP_setColumnDataAsNominalFunc(setColumnDataFuncDef func)
+{
+	_jaspRCPP_setColumnDataAsNominalFunc = func;
+}
+void jaspColumn::set_jaspRCPP_setColumnDataAsNominalFuncXPtr(Rcpp::XPtr<setColumnDataFuncDef> func)
+{
+	set_jaspRCPP_setColumnDataAsNominalFunc(*func);
+}
 
-#endif
+void jaspColumn::set_jaspRCPP_setColumnDataAsNominalTextFunc(setColumnDataFuncDef func)
+{
+	_jaspRCPP_setColumnDataAsNominalTextFunc = func;
+}
+void jaspColumn::set_jaspRCPP_setColumnDataAsNominalTextFuncXPtr(Rcpp::XPtr<setColumnDataFuncDef> func)
+{
+	set_jaspRCPP_setColumnDataAsNominalTextFunc(*func);
+}
+
+void jaspColumn::set_jaspRCPP_getColumnTypeFunc(getColumnTypeFuncDef func)
+{
+	_jaspRCPP_getColumnTypeFunc = func;
+}
+void jaspColumn::set_jaspRCPP_getColumnTypeFuncXPtr(Rcpp::XPtr<getColumnTypeFuncDef> func)
+{
+	set_jaspRCPP_getColumnTypeFunc(*func);
+}
+
+bool	jaspColumn::jaspRCPP_setColumnDataAsScale(			std::string columnName, Rcpp::RObject scalarData) { if (_jaspRCPP_setColumnDataAsScaleFunc			== nullptr) { jaspPrint("jaspColumn does nothing in R stand-alone!"); return false;} else return (*_jaspRCPP_setColumnDataAsScaleFunc)(columnName, scalarData); }
+bool	jaspColumn::jaspRCPP_setColumnDataAsOrdinal(		std::string columnName, Rcpp::RObject scalarData) { if (_jaspRCPP_setColumnDataAsOrdinalFunc		== nullptr) { jaspPrint("jaspColumn does nothing in R stand-alone!"); return false;} else return (*_jaspRCPP_setColumnDataAsOrdinalFunc)(columnName, scalarData); }
+bool	jaspColumn::jaspRCPP_setColumnDataAsNominal(		std::string columnName, Rcpp::RObject scalarData) { if (_jaspRCPP_setColumnDataAsNominalFunc		== nullptr) { jaspPrint("jaspColumn does nothing in R stand-alone!"); return false;} else return (*_jaspRCPP_setColumnDataAsNominalFunc)(columnName, scalarData); }
+bool	jaspColumn::jaspRCPP_setColumnDataAsNominalText(	std::string columnName, Rcpp::RObject scalarData) { if (_jaspRCPP_setColumnDataAsNominalTextFunc	== nullptr) { jaspPrint("jaspColumn does nothing in R stand-alone!"); return false;} else return (*_jaspRCPP_setColumnDataAsNominalTextFunc)(columnName, scalarData); }
+
+columnType jaspColumn::jaspRCPP_getColumnType(std::string columnName) { return (_jaspRCPP_getColumnTypeFunc == nullptr) ? columnType::unknown : (*_jaspRCPP_getColumnTypeFunc)(columnName); }
 
 jaspColumn::jaspColumn(std::string columnName)
 	: jaspObject(jaspObjectType::column, "jaspColumn for " + columnName)

--- a/src/jaspColumn.h
+++ b/src/jaspColumn.h
@@ -3,9 +3,13 @@
 
 #include "jaspObject.h"
 #include "columntype.h"
+#include <Rcpp.h>
 
 typedef bool			(*setColumnDataFuncDef)	(std::string, Rcpp::RObject);
 typedef columnType		(*getColumnTypeFuncDef)	(std::string);
+
+typedef  Rcpp::XPtr<setColumnDataFuncDef> colDataF;
+typedef  Rcpp::XPtr<getColumnTypeFuncDef> colgetTF;
 
 class jaspColumn : public jaspObject
 {
@@ -26,18 +30,8 @@ public:
 	void setNominal(	Rcpp::RObject nominalData);
 	void setNominalText(Rcpp::RObject nominalData);
 
-	static void			set_jaspRCPP_setColumnDataAsScaleFunc(setColumnDataFuncDef func);
-	static void			set_jaspRCPP_setColumnDataAsOrdinalFunc(setColumnDataFuncDef func);
-	static void			set_jaspRCPP_setColumnDataAsNominalFunc(setColumnDataFuncDef func);
-	static void			set_jaspRCPP_setColumnDataAsNominalTextFunc(setColumnDataFuncDef func);
-	static void			set_jaspRCPP_getColumnTypeFunc(getColumnTypeFuncDef func);
 
-	static void			set_jaspRCPP_setColumnDataAsScaleFuncXPtr(Rcpp::XPtr<setColumnDataFuncDef> func);
-	static void			set_jaspRCPP_setColumnDataAsOrdinalFuncXPtr(Rcpp::XPtr<setColumnDataFuncDef> func);
-	static void			set_jaspRCPP_setColumnDataAsNominalFuncXPtr(Rcpp::XPtr<setColumnDataFuncDef> func);
-	static void			set_jaspRCPP_setColumnDataAsNominalTextFuncXPtr(Rcpp::XPtr<setColumnDataFuncDef> func);
-	static void			set_jaspRCPP_getColumnTypeFuncXPtr(Rcpp::XPtr<getColumnTypeFuncDef> func);
-
+	static void setColumnFuncs(colDataF scalar, colDataF ordinal, colDataF nominal, colDataF nominalText, colgetTF colType);
 
 private:
 	std::string		_columnName		= "";
@@ -45,17 +39,17 @@ private:
 					_typeChanged	= false;
 	jaspColumnType	_columnType		= jaspColumnType::unknown;
 
-	bool			jaspRCPP_setColumnDataAsScale(			std::string columnName, Rcpp::RObject scalarData);
-	bool			jaspRCPP_setColumnDataAsOrdinal(		std::string columnName, Rcpp::RObject scalarData);
-	bool			jaspRCPP_setColumnDataAsNominal(		std::string columnName, Rcpp::RObject scalarData);
-	bool			jaspRCPP_setColumnDataAsNominalText(	std::string columnName, Rcpp::RObject scalarData);
-	columnType		jaspRCPP_getColumnType(					std::string columnName							);
+	bool			setColumnDataAsScale(		const std::string & columnName, Rcpp::RObject data);
+	bool			setColumnDataAsOrdinal(		const std::string & columnName, Rcpp::RObject data);
+	bool			setColumnDataAsNominal(		const std::string & columnName, Rcpp::RObject data);
+	bool			setColumnDataAsNominalText(	const std::string & columnName, Rcpp::RObject data);
+	columnType		getColumnType(				const std::string & columnName							);
 
-	static setColumnDataFuncDef		_jaspRCPP_setColumnDataAsScaleFunc,
-									_jaspRCPP_setColumnDataAsOrdinalFunc,
-									_jaspRCPP_setColumnDataAsNominalFunc,
-									_jaspRCPP_setColumnDataAsNominalTextFunc;
-	static getColumnTypeFuncDef		_jaspRCPP_getColumnTypeFunc;
+	static setColumnDataFuncDef		_setColumnDataAsScaleFunc,
+									_setColumnDataAsOrdinalFunc,
+									_setColumnDataAsNominalFunc,
+									_setColumnDataAsNominalTextFunc;
+	static getColumnTypeFuncDef		_getColumnTypeFunc;
 
 
 

--- a/src/jaspColumn.h
+++ b/src/jaspColumn.h
@@ -2,6 +2,10 @@
 #define _JASPCOLUMN_HEADER
 
 #include "jaspObject.h"
+#include "columntype.h"
+
+typedef bool			(*setColumnDataFuncDef)	(std::string, Rcpp::RObject);
+typedef columnType		(*getColumnTypeFuncDef)	(std::string);
 
 class jaspColumn : public jaspObject
 {
@@ -22,11 +26,39 @@ public:
 	void setNominal(	Rcpp::RObject nominalData);
 	void setNominalText(Rcpp::RObject nominalData);
 
+	static void			set_jaspRCPP_setColumnDataAsScaleFunc(setColumnDataFuncDef func);
+	static void			set_jaspRCPP_setColumnDataAsOrdinalFunc(setColumnDataFuncDef func);
+	static void			set_jaspRCPP_setColumnDataAsNominalFunc(setColumnDataFuncDef func);
+	static void			set_jaspRCPP_setColumnDataAsNominalTextFunc(setColumnDataFuncDef func);
+	static void			set_jaspRCPP_getColumnTypeFunc(getColumnTypeFuncDef func);
+
+	static void			set_jaspRCPP_setColumnDataAsScaleFuncXPtr(Rcpp::XPtr<setColumnDataFuncDef> func);
+	static void			set_jaspRCPP_setColumnDataAsOrdinalFuncXPtr(Rcpp::XPtr<setColumnDataFuncDef> func);
+	static void			set_jaspRCPP_setColumnDataAsNominalFuncXPtr(Rcpp::XPtr<setColumnDataFuncDef> func);
+	static void			set_jaspRCPP_setColumnDataAsNominalTextFuncXPtr(Rcpp::XPtr<setColumnDataFuncDef> func);
+	static void			set_jaspRCPP_getColumnTypeFuncXPtr(Rcpp::XPtr<getColumnTypeFuncDef> func);
+
+
 private:
 	std::string		_columnName		= "";
 	bool			_dataChanged	= false,
 					_typeChanged	= false;
 	jaspColumnType	_columnType		= jaspColumnType::unknown;
+
+	bool			jaspRCPP_setColumnDataAsScale(			std::string columnName, Rcpp::RObject scalarData);
+	bool			jaspRCPP_setColumnDataAsOrdinal(		std::string columnName, Rcpp::RObject scalarData);
+	bool			jaspRCPP_setColumnDataAsNominal(		std::string columnName, Rcpp::RObject scalarData);
+	bool			jaspRCPP_setColumnDataAsNominalText(	std::string columnName, Rcpp::RObject scalarData);
+	columnType		jaspRCPP_getColumnType(					std::string columnName							);
+
+	static setColumnDataFuncDef		_jaspRCPP_setColumnDataAsScaleFunc,
+									_jaspRCPP_setColumnDataAsOrdinalFunc,
+									_jaspRCPP_setColumnDataAsNominalFunc,
+									_jaspRCPP_setColumnDataAsNominalTextFunc;
+	static getColumnTypeFuncDef		_jaspRCPP_getColumnTypeFunc;
+
+
+
 };
 
 

--- a/src/jaspContainer.cpp
+++ b/src/jaspContainer.cpp
@@ -59,7 +59,7 @@ jaspContainer * jaspContainer::jaspContainerFromRcppList(Rcpp::List convertThis)
 
 	for(int i=0; i<convertThis.size(); i++)
 		if(colNamesVec[i] == "title")
-			newContainer->_title = jaspNativeToUtf8(Rcpp::RObject(convertThis[i]));
+			newContainer->_title = Rcpp::String(Rcpp::RObject(convertThis[i]));
 		else
 			newContainer->insert(colNamesVec[i], convertThis[i]);
 
@@ -471,7 +471,7 @@ void jaspContainer::setError()
 
 void jaspContainer::setError(Rcpp::String message)
 {
-	_errorMessage = jaspNativeToUtf8(message);
+	_errorMessage = message;
 	setError();
 }
 

--- a/src/jaspHtml.h
+++ b/src/jaspHtml.h
@@ -4,7 +4,7 @@
 class jaspHtml : public jaspObject
 {
 public:
-  jaspHtml(Rcpp::String text = "", std::string elementType = "p", std::string maxWidth="15cm", std::string Class = "") : jaspObject(jaspObjectType::html, ""), _rawText(jaspNativeToUtf8(text)), _elementType(elementType), _class(Class), _maxWidth(maxWidth) {}
+  jaspHtml(Rcpp::String text = "", std::string elementType = "p", std::string maxWidth="15cm", std::string Class = "") : jaspObject(jaspObjectType::html, ""), _rawText(text), _elementType(elementType), _class(Class), _maxWidth(maxWidth) {}
 
 	~jaspHtml() {}
 
@@ -33,7 +33,7 @@ class jaspHtml_Interface : public jaspObject_Interface
 public:
 	jaspHtml_Interface(jaspObject * dataObj) : jaspObject_Interface(dataObj) {}
 
-    void			setText(Rcpp::String newRawText) { 			static_cast<jaspHtml *>(myJaspObject)->setText(jaspNativeToUtf8(newRawText)); }
+	void			setText(Rcpp::String newRawText) { 			static_cast<jaspHtml *>(myJaspObject)->setText(newRawText); }
     Rcpp::String	getText() 						{ return 	static_cast<jaspHtml *>(myJaspObject)->getText(); }
     std::string		getHtml()						{ return	static_cast<jaspHtml *>(myJaspObject)->getHtml(); }
 

--- a/src/jaspModuleRegistration.h
+++ b/src/jaspModuleRegistration.h
@@ -23,48 +23,45 @@ RCPP_MODULE(jaspResults)
 	JASP_OBJECT_CREATOR_FUNCTIONREGISTRATION(jaspQmlSource);
 
 
-	Rcpp::function("cpp_startProgressbar",	jaspResults::staticStartProgressbar);
-	Rcpp::function("cpp_progressbarTick",	jaspResults::staticProgressbarTick);
+	Rcpp::function("cpp_startProgressbar",				jaspResults::staticStartProgressbar);
+	Rcpp::function("cpp_progressbarTick",				jaspResults::staticProgressbarTick);
 
-	Rcpp::function("destroyAllAllocatedObjects", jaspObject::destroyAllAllocatedObjects);
-	Rcpp::function("setSendFunc",					jaspResults::setSendFuncXPtr);
-	Rcpp::function("setPollMessagesFunc",			jaspResults::setPollMessagesFuncXPtr);
-	Rcpp::function("setBaseCitation",				jaspResults::setBaseCitation);
-	Rcpp::function("setInsideJasp",					jaspResults::setInsideJASP);
-	Rcpp::function("isInsideJASP",					jaspResults::isInsideJASP);
-	Rcpp::function("writeSealFilename",				jaspResults::writeSealFilename);
-	Rcpp::function("setResponseData",				jaspResults::setResponseData);
-	Rcpp::function("setDeveloperMode",				jaspResults::setDeveloperMode);
-	Rcpp::function("setSaveLocation",				jaspResults::setSaveLocation);
-	Rcpp::function("setWriteSealLocation",			jaspResults::setWriteSealLocation);
+	Rcpp::function("destroyAllAllocatedObjects",		jaspObject::destroyAllAllocatedObjects);
+	Rcpp::function("setSendFunc",						jaspResults::setSendFunc);
+	Rcpp::function("setPollMessagesFunc",				jaspResults::setPollMessagesFunc);
+	Rcpp::function("setBaseCitation",					jaspResults::setBaseCitation);
+	Rcpp::function("setInsideJasp",						jaspResults::setInsideJASP);
+	Rcpp::function("isInsideJASP",						jaspResults::isInsideJASP);
+	Rcpp::function("writeSealFilename",					jaspResults::writeSealFilename);
+	Rcpp::function("setResponseData",					jaspResults::setResponseData);
+	Rcpp::function("setDeveloperMode",					jaspResults::setDeveloperMode);
+	Rcpp::function("setSaveLocation",					jaspResults::setSaveLocation);
+	Rcpp::function("setWriteSealLocation",				jaspResults::setWriteSealLocation);
 
-	Rcpp::function("setColumnDataAsScaleFunc",			jaspColumn::set_jaspRCPP_setColumnDataAsScaleFuncXPtr);
-	Rcpp::function("setColumnDataAsOrdinalFunc",		jaspColumn::set_jaspRCPP_setColumnDataAsOrdinalFuncXPtr);
-	Rcpp::function("setColumnDataAsNominalFunc",		jaspColumn::set_jaspRCPP_setColumnDataAsNominalFuncXPtr);
-	Rcpp::function("setColumnDataAsNominalTextFunc",	jaspColumn::set_jaspRCPP_setColumnDataAsNominalTextFuncXPtr);
-	Rcpp::function("setColumnTypeFunc",					jaspColumn::set_jaspRCPP_getColumnTypeFuncXPtr);
+	Rcpp::function("setColumnFuncs",					jaspColumn::setColumnFuncs);
+	Rcpp::function("setJaspLogFunction",				setJaspLogFunction);
 
 
 	Rcpp::class_<jaspObject_Interface>("jaspObject")
 
-		.method("print",							&jaspObject_Interface::print,											"Prints the contents of the jaspObject")
-		.method("toHtml",							&jaspObject_Interface::toHtml,											"gives a string with the contents of the jaspObject nicely formatted as html")
-		.method("printHtml",						&jaspObject_Interface::printHtml,										"Prints the contents of the jaspObject nicely formatted as html")
+		.method("print",							&	jaspObject_Interface::print,											"Prints the contents of the jaspObject")
+		.method("toHtml",							&	jaspObject_Interface::toHtml,											"gives a string with the contents of the jaspObject nicely formatted as html")
+		.method("printHtml",						&	jaspObject_Interface::printHtml,										"Prints the contents of the jaspObject nicely formatted as html")
 
-		.method("addMessage",						&jaspObject_Interface::addMessage,										"Add a message to this object")
-		.method("addCitation",						&jaspObject_Interface::addCitation,										"Add a citation to this object")
+		.method("addMessage",						&	jaspObject_Interface::addMessage,										"Add a message to this object")
+		.method("addCitation",						&	jaspObject_Interface::addCitation,										"Add a citation to this object")
 
-		.property("title",							&jaspObject_Interface::getTitle,	&jaspObject_Interface::setTitle,	"Set the title of this object")
-		.property("info",							&jaspObject_Interface::getInfo,		&jaspObject_Interface::setInfo,		"Set info aka help MD for this object")
-		.property("position",						&jaspObject_Interface::getPosition,	&jaspObject_Interface::setPosition,	"Set the position of this object in it's container. By default this is at the end in the order of adding. You can specify any other value, they do not need to be next to each other or unique. The rule is: lower values (including negative) are higher in the container and when multiple objects in a container have the same position-value order is derived from adding-order.")
-		.property("type",							&jaspObject_Interface::type,											"The type of this jaspObject as a string, something like: container, table, plot, json, list, results, html, state")
+		.property("title",							&	jaspObject_Interface::getTitle,		&jaspObject_Interface::setTitle,	"Set the title of this object")
+		.property("info",							&	jaspObject_Interface::getInfo,		&jaspObject_Interface::setInfo,		"Set info aka help MD for this object")
+		.property("position",						&	jaspObject_Interface::getPosition,	&jaspObject_Interface::setPosition,	"Set the position of this object in it's container. By default this is at the end in the order of adding. You can specify any other value, they do not need to be next to each other or unique. The rule is: lower values (including negative) are higher in the container and when multiple objects in a container have the same position-value order is derived from adding-order.")
+		.property("type",							&	jaspObject_Interface::type,												"The type of this jaspObject as a string, something like: container, table, plot, json, list, results, html, state")
 
-		.method("setOptionMustBeDependency",		&jaspObject_Interface::setOptionMustBeDependency,						"Specifies an option and it's required value, if the analysis is restarted and this option is no longer defined (like that) it will automatically destroy the object. Otherwise it will keep it.")
-		.method("setOptionMustContainDependency",	&jaspObject_Interface::setOptionMustContainDependency,					"Specifies an option that should define an array and a required value that should be in it, if the analysis is restarted and this option is no longer defined or no longer contains the specified value it will automatically destroy the object. Otherwise it will keep it.")
-		.method("dependOnOptions",					&jaspObject_Interface::dependOnOptions,									"Will make the object depend on the current values of the options specified in the charactervector.")
-		.method("copyDependenciesFromJaspObject",	&jaspObject_Interface::copyDependenciesFromJaspObject,					"Will make the object depend on whatever the other jaspObject depends.")
-  		.method("getError",							&jaspObject_Interface::getError, 										"Get the error status of this object.")
-    	.method("setError",							&jaspObject_Interface::setError, 										"Set an error message on this object that which be shown in JASP. Errors set on jaspContainers or jaspResults are propagated to children, such that the first child shows the error and the others are greyed out.")
+		.method("setOptionMustBeDependency",		&	jaspObject_Interface::setOptionMustBeDependency,						"Specifies an option and it's required value, if the analysis is restarted and this option is no longer defined (like that) it will automatically destroy the object. Otherwise it will keep it.")
+		.method("setOptionMustContainDependency",	&	jaspObject_Interface::setOptionMustContainDependency,					"Specifies an option that should define an array and a required value that should be in it, if the analysis is restarted and this option is no longer defined or no longer contains the specified value it will automatically destroy the object. Otherwise it will keep it.")
+		.method("dependOnOptions",					&	jaspObject_Interface::dependOnOptions,									"Will make the object depend on the current values of the options specified in the charactervector.")
+		.method("copyDependenciesFromJaspObject",	&	jaspObject_Interface::copyDependenciesFromJaspObject,					"Will make the object depend on whatever the other jaspObject depends.")
+		.method("getError",							&	jaspObject_Interface::getError, 										"Get the error status of this object.")
+		.method("setError",							&	jaspObject_Interface::setError, 										"Set an error message on this object that which be shown in JASP. Errors set on jaspContainers or jaspResults are propagated to children, such that the first child shows the error and the others are greyed out.")
 	;
 
 	Rcpp::class_<jaspContainer_Interface>("jaspContainer")

--- a/src/jaspModuleRegistration.h
+++ b/src/jaspModuleRegistration.h
@@ -1,5 +1,6 @@
 #include <Rcpp.h>
 #include "jaspResults.h"
+#include "jaspColumn.h"
 
 JASP_OBJECT_CREATOR(jaspHtml)
 JASP_OBJECT_CREATOR(jaspPlot)
@@ -36,6 +37,13 @@ RCPP_MODULE(jaspResults)
 	Rcpp::function("setDeveloperMode",				jaspResults::setDeveloperMode);
 	Rcpp::function("setSaveLocation",				jaspResults::setSaveLocation);
 	Rcpp::function("setWriteSealLocation",			jaspResults::setWriteSealLocation);
+
+	Rcpp::function("setColumnDataAsScaleFunc",			jaspColumn::set_jaspRCPP_setColumnDataAsScaleFuncXPtr);
+	Rcpp::function("setColumnDataAsOrdinalFunc",		jaspColumn::set_jaspRCPP_setColumnDataAsOrdinalFuncXPtr);
+	Rcpp::function("setColumnDataAsNominalFunc",		jaspColumn::set_jaspRCPP_setColumnDataAsNominalFuncXPtr);
+	Rcpp::function("setColumnDataAsNominalTextFunc",	jaspColumn::set_jaspRCPP_setColumnDataAsNominalTextFuncXPtr);
+	Rcpp::function("setColumnTypeFunc",					jaspColumn::set_jaspRCPP_getColumnTypeFuncXPtr);
+
 
 	Rcpp::class_<jaspObject_Interface>("jaspObject")
 

--- a/src/jaspObject.cpp
+++ b/src/jaspObject.cpp
@@ -1,9 +1,5 @@
 #define ENUM_DECLARATION_CPP
 #include "jaspObject.h"
-
-//Now we undef it again to avoid making a second implementation of columntype.o in here
-#undef ENUM_DECLARATION_CPP
-//#include "jaspResults.h"
 #include <chrono>
 
 #ifdef BUILDING_JASP
@@ -64,7 +60,6 @@ void jaspPrint(std::string msg)
 	_jaspRCPP_logString(msg + "\n");
 #else
 	Rcpp::Rcout << msg << "\n";
-	//Rprintf(msg.c_str());
 #endif
 }
 

--- a/src/jaspObject.cpp
+++ b/src/jaspObject.cpp
@@ -1,6 +1,9 @@
 #define ENUM_DECLARATION_CPP
 #include "jaspObject.h"
-#include "jaspResults.h"
+
+//Now we undef it again to avoid making a second implementation of columntype.o in here
+#undef ENUM_DECLARATION_CPP
+//#include "jaspResults.h"
 #include <chrono>
 
 #ifdef BUILDING_JASP
@@ -46,35 +49,22 @@ std::vector<std::string> stringSplit(std::string str, char kar)
 	return strs;
 }
 
+logFuncDef _jaspRCPP_logString = nullptr;
+
+void		setJaspLogFunction(Rcpp::XPtr<logFuncDef> func)
+{
+	_jaspRCPP_logString = * func;
+
+	_jaspRCPP_logString("Log string function received loud and clear!");
+}
+
 void jaspPrint(std::string msg)
 {
 #ifdef JASP_R_INTERFACE_LIBRARY
-	jaspRCPP_logString(msg + "\n");
+	_jaspRCPP_logString(msg + "\n");
 #else
 	Rcpp::Rcout << msg << "\n";
 	//Rprintf(msg.c_str());
-#endif
-}
-
-std::string jaspNativeToUtf8(const Rcpp::RObject &in)
-{
-	if(in.isNULL())
-		return "";
-	
-	return jaspNativeToUtf8(Rcpp::as<Rcpp::String>(in));
-}
-
-
-std::string jaspNativeToUtf8(const Rcpp::String & in)
-{
-#ifdef _WIN32
-	#ifdef JASP_R_INTERFACE_LIBRARY
-		return jaspRCPP_nativeToUtf8(in);
-	#else
-		return in; //If running in R then it's the users problem really.
-	#endif	
-#else
-	return in;
 #endif
 }
 
@@ -217,7 +207,7 @@ Rcpp::DataFrame jaspObject::convertFactorsToCharacters(Rcpp::DataFrame df)
 
 			for(int i=0; i<originalColumn.size(); i++)
 				if(originalColumn[i] > 0) //it can be INT_MIN at least, but if we are doing a -1 on it anyhow it should just be bigger than 0
-					charCol[i] = jaspNativeToUtf8(factorLevels[originalColumn[i] - 1]);
+					charCol[i] = factorLevels[originalColumn[i] - 1];
 
 			df[col] = charCol;
 		}

--- a/src/jaspPlot.cpp
+++ b/src/jaspPlot.cpp
@@ -107,13 +107,13 @@ void jaspPlot::renderPlot()
 			plotInfo["obj"] = writeResult["obj"];
 
 		if(writeResult.containsElementNamed("png"))
-			_filePathPng = jaspNativeToUtf8(Rcpp::as<Rcpp::String>(writeResult["png"]));
+			_filePathPng = Rcpp::as<Rcpp::String>(writeResult["png"]);
 
 		_editOptions = Json::nullValue;
 
 		if(writeResult.containsElementNamed("editOptions") && !Rf_isNull(writeResult["editOptions"]))
 		{
-			std::string editOptionsStr = jaspNativeToUtf8(Rcpp::as<Rcpp::String>(writeResult["editOptions"]));
+			std::string editOptionsStr = Rcpp::as<Rcpp::String>(writeResult["editOptions"]);
 
 			if(editOptionsStr != "")
 			{
@@ -133,7 +133,7 @@ void jaspPlot::renderPlot()
 		if(writeResult.containsElementNamed("error"))
 		{
 			_error			= true;
-			_errorMessage	= jaspNativeToUtf8(Rcpp::as<Rcpp::String>(writeResult["error"]));
+			_errorMessage	= Rcpp::as<Rcpp::String>(writeResult["error"]);
 		}
 		else
 		{

--- a/src/jaspResults.cpp
+++ b/src/jaspResults.cpp
@@ -21,24 +21,14 @@ Rcpp::Environment*	jaspResults::_RStorageEnv		= nullptr;
 bool				jaspResults::_insideJASP		= false;
 jaspResults*		jaspResults::_jaspResults		= nullptr;
 
-void jaspResults::setSendFunc(sendFuncDef sendFunc)
+void jaspResults::setSendFunc(Rcpp::XPtr<sendFuncDef> sendFunc)
 {
-	_ipccSendFunc = sendFunc;
+	_ipccSendFunc = *sendFunc;
 }
 
-void jaspResults::setSendFuncXPtr(Rcpp::XPtr<sendFuncDef> sendFunc)
+void jaspResults::setPollMessagesFunc(Rcpp::XPtr<pollMessagesFuncDef> pollFunc)
 {
-	setSendFunc(*sendFunc);
-}
-
-void jaspResults::setPollMessagesFunc(pollMessagesFuncDef pollFunc)
-{
-	_ipccPollFunc = pollFunc;
-}
-
-void jaspResults::setPollMessagesFuncXPtr(Rcpp::XPtr<pollMessagesFuncDef> pollFunc)
-{
-	setPollMessagesFunc(*pollFunc);
+	_ipccPollFunc = *pollFunc;
 }
 
 void jaspResults::setBaseCitation(std::string baseCitation)
@@ -426,7 +416,7 @@ Json::Value jaspResults::dataEntry(std::string &) const
 
 void jaspResults::setErrorMessage(Rcpp::String msg, std::string errorStatus)
 {
-	errorMessage = jaspNativeToUtf8(msg);
+	errorMessage = msg;
 	setStatus(errorStatus);
 }
 
@@ -577,7 +567,7 @@ void jaspResults::startProgressbar(int expectedTicks, Rcpp::String label)
 
 	Json::Value progress;
 	progress["value"]		= 0;
-	progress["label"]		= jaspNativeToUtf8(label);
+	progress["label"]		= std::string(label);
 	_response["progress"]	= progress;
 
 	send();

--- a/src/jaspResults.h
+++ b/src/jaspResults.h
@@ -1,13 +1,14 @@
 #pragma once
 #include "jaspContainer.h"
 
-#ifdef JASP_R_INTERFACE_LIBRARY
-#include "jasprcpp_interface.h"
-
-#define GUARD_ENCODE_FUNCS(...) throw std::runtime_error("Do not use column encoding from jaspResults when running in JASP!");
-#else
+//copied from jasprcpp_interface.h
 typedef void (*sendFuncDef)(const char *);
 typedef bool (*pollMessagesFuncDef)();
+
+#ifdef JASP_R_INTERFACE_LIBRARY
+#define GUARD_ENCODE_FUNCS(...) throw std::runtime_error("Do not use column encoding from jaspResults when running in JASP!");
+#else
+
 //If you edit any function(signatures) or objects for JASP* Rcpp modules and you want to run it as an R-Package you should run Rcpp::compileAttributes from an R instance started in $PWD/R-Interface/jaspResults
 
 #include "columnencoder.h"
@@ -25,10 +26,8 @@ public:
 	~jaspResults();
 
 	//static functions to allow the values to be set before the constructor is called from R. Would be nicer to just run the constructor in C++ maybe?
-	static void			setSendFunc(sendFuncDef sendFunc);
-	static void			setSendFuncXPtr(Rcpp::XPtr<sendFuncDef> sendFunc);
-	static void			setPollMessagesFunc(pollMessagesFuncDef pollFunc);
-	static void			setPollMessagesFuncXPtr(Rcpp::XPtr<pollMessagesFuncDef> pollFunc);
+	static void			setSendFunc(Rcpp::XPtr<sendFuncDef> sendFunc);
+	static void			setPollMessagesFunc(Rcpp::XPtr<pollMessagesFuncDef> pollFunc);
 	static void			setResponseData(int analysisID, int revision);
 	static void			setSaveLocation(const std::string & root, const std::string & relativePath);
 	static void			setWriteSealLocation(const std::string & root, const std::string & relativePath);

--- a/src/jaspTable.cpp
+++ b/src/jaspTable.cpp
@@ -1102,8 +1102,8 @@ void jaspTable::addFootnote(Rcpp::RObject message, Rcpp::RObject symbol, Rcpp::R
 	if (message.isNULL())
 		Rf_error("One would expect a footnote to at least contain a message..");
 		
-	std::string strMessage	= jaspNativeToUtf8(message);
-	std::string strSymbol	= symbol.isNULL() ? "" : jaspNativeToUtf8(symbol);
+	std::string strMessage	= Rcpp::String(message);
+	std::string strSymbol	= symbol.isNULL() ? "" : Rcpp::String(symbol);
 	
 	std::vector<Json::Value> colNames;
 	if (!col_names.isNULL())
@@ -1336,11 +1336,11 @@ void jaspTable::addColumnInfo(Rcpp::RObject name, Rcpp::RObject title, Rcpp::ROb
 
 	std::string lastAddedColName = getColName(_colNames.rowCount() - 1);
 
-	if(!title.isNULL())		_colTitles[		lastAddedColName ] = jaspNativeToUtf8(title);
-	if(!type.isNULL())		_colTypes[		lastAddedColName ] = jaspNativeToUtf8(type);
-	if(!format.isNULL())	_colFormats[	lastAddedColName ] = jaspNativeToUtf8(format);
+	if(!title.isNULL())		_colTitles[		lastAddedColName ] = Rcpp::String(title);
+	if(!type.isNULL())		_colTypes[		lastAddedColName ] = Rcpp::String(type);
+	if(!format.isNULL())	_colFormats[	lastAddedColName ] = Rcpp::String(format);
+	if(!overtitle.isNULL())	_colOvertitles[	lastAddedColName ] = Rcpp::String(overtitle);
 	if(!combine.isNULL())	_colCombines[	lastAddedColName ] = Rcpp::as<bool>(combine);
-	if(!overtitle.isNULL())	_colOvertitles[	lastAddedColName ] = jaspNativeToUtf8(overtitle);
 }
 
 


### PR DESCRIPTION
Make sure pointers are passed to jaspBase with relevant functions for computed columns etc

Part of the fix for https://github.com/jasp-stats/jasp-test-release/issues/1967

Also couldnt resist removing all the now no longer necessary jaspNativeUtf8??? functions etc