### PR TITLE
Add dependencies on nested options

### DIFF
--- a/R/zzzWrappers.R
+++ b/R/zzzWrappers.R
@@ -237,7 +237,7 @@ jaspObjR <- R6::R6Class(
   public    = list(
     initialize = function()	stop("You should not create a new jaspObject!", domain = NA),
     print      = function()	private$jaspObject$print(),
-    dependOn   = function(options=NULL, optionsFromObject=NULL, optionContainsValue=NULL) {
+    dependOn   = function(options=NULL, optionsFromObject=NULL, optionContainsValue=NULL, nestedOptions = NULL, nestedOptionsContainsValue = NULL) {
       if (!is.null(options)) {
         if (!is.character(options))
           stop("please provide a character vector in `options`", domain = NA)
@@ -268,6 +268,42 @@ jaspObjR <- R6::R6Class(
           private$jaspObject$setOptionMustContainDependency(name, value)
         }
       }
+
+      if (!is.null(nestedOptions)) {
+        # TODO: how are unnamed list elements treated? For example
+        # options <- list(model = list(list(option = TRUE),
+        #                              list(option = FALSE))
+        # how should we specify [["model"]][[2]][["option"]] as a dependency?
+        if (is.character(nestedOptions))
+          private$jaspObject$dependOnNestedOptions(nestedOptions)
+        else if (is.list(nestedOptions))
+          for (el in nestedOptions) {
+            if (is.character(el))
+              private$jaspObject$dependOnNestedOptions(el)
+            else
+              stop("Argument `nestedOptions` got something that was not a character but of class ", paste(class(el), collapse = ", "), domain = NA)
+          }
+        else
+          stop("Argument `nestedOptions` got something that was not a character but of class ", paste(class(nestedOptions), collapse = ", "), domain = NA)
+      }
+
+      if (!is.null(nestedOptionsContainsValue)) {
+        # TODO: flatten list into key - value pairs
+        if (!is.list(nestedOptionsContainsValue))
+          stop("Argument `nestedOptionsContainsValue` got something that was not a list but of class ", paste(class(el), collapse = ", "), domain = NA)
+        if (is.character(nestedOptions))
+          private$jaspObject$setNestedOptionMustContainDependency(nestedOptions)
+        else if (is.list(nestedOptions))
+          for (el in nestedOptions) {
+            if (is.character(el))
+              private$jaspObject$setNestedOptionMustContainDependency(el)
+            else
+              stop("Argument `nestedOptions` got something that was not a character but of class ", paste(class(el), collapse = ", "), domain = NA)
+          }
+        else
+          stop("Argument `nestedOptions` got something that was not a character but of class ", paste(class(nestedOptions), collapse = ", "), domain = NA)
+      }
+
     }
   ),
   private = list(

--- a/src/jaspModuleRegistration.h
+++ b/src/jaspModuleRegistration.h
@@ -44,24 +44,27 @@ RCPP_MODULE(jaspResults)
 
 	Rcpp::class_<jaspObject_Interface>("jaspObject")
 
-		.method("print",							&	jaspObject_Interface::print,											"Prints the contents of the jaspObject")
-		.method("toHtml",							&	jaspObject_Interface::toHtml,											"gives a string with the contents of the jaspObject nicely formatted as html")
-		.method("printHtml",						&	jaspObject_Interface::printHtml,										"Prints the contents of the jaspObject nicely formatted as html")
+		.method("print",								&	jaspObject_Interface::print,											"Prints the contents of the jaspObject")
+		.method("toHtml",								&	jaspObject_Interface::toHtml,											"gives a string with the contents of the jaspObject nicely formatted as html")
+		.method("printHtml",							&	jaspObject_Interface::printHtml,										"Prints the contents of the jaspObject nicely formatted as html")
 
-		.method("addMessage",						&	jaspObject_Interface::addMessage,										"Add a message to this object")
-		.method("addCitation",						&	jaspObject_Interface::addCitation,										"Add a citation to this object")
+		.method("addMessage",							&	jaspObject_Interface::addMessage,										"Add a message to this object")
+		.method("addCitation",							&	jaspObject_Interface::addCitation,										"Add a citation to this object")
 
-		.property("title",							&	jaspObject_Interface::getTitle,		&jaspObject_Interface::setTitle,	"Set the title of this object")
-		.property("info",							&	jaspObject_Interface::getInfo,		&jaspObject_Interface::setInfo,		"Set info aka help MD for this object")
-		.property("position",						&	jaspObject_Interface::getPosition,	&jaspObject_Interface::setPosition,	"Set the position of this object in it's container. By default this is at the end in the order of adding. You can specify any other value, they do not need to be next to each other or unique. The rule is: lower values (including negative) are higher in the container and when multiple objects in a container have the same position-value order is derived from adding-order.")
-		.property("type",							&	jaspObject_Interface::type,												"The type of this jaspObject as a string, something like: container, table, plot, json, list, results, html, state")
+		.property("title",								&	jaspObject_Interface::getTitle,		&jaspObject_Interface::setTitle,	"Set the title of this object")
+		.property("info",								&	jaspObject_Interface::getInfo,		&jaspObject_Interface::setInfo,		"Set info aka help MD for this object")
+		.property("position",							&	jaspObject_Interface::getPosition,	&jaspObject_Interface::setPosition,	"Set the position of this object in it's container. By default this is at the end in the order of adding. You can specify any other value, they do not need to be next to each other or unique. The rule is: lower values (including negative) are higher in the container and when multiple objects in a container have the same position-value order is derived from adding-order.")
+		.property("type",								&	jaspObject_Interface::type,												"The type of this jaspObject as a string, something like: container, table, plot, json, list, results, html, state")
 
-		.method("setOptionMustBeDependency",		&	jaspObject_Interface::setOptionMustBeDependency,						"Specifies an option and it's required value, if the analysis is restarted and this option is no longer defined (like that) it will automatically destroy the object. Otherwise it will keep it.")
-		.method("setOptionMustContainDependency",	&	jaspObject_Interface::setOptionMustContainDependency,					"Specifies an option that should define an array and a required value that should be in it, if the analysis is restarted and this option is no longer defined or no longer contains the specified value it will automatically destroy the object. Otherwise it will keep it.")
-		.method("dependOnOptions",					&	jaspObject_Interface::dependOnOptions,									"Will make the object depend on the current values of the options specified in the charactervector.")
-		.method("copyDependenciesFromJaspObject",	&	jaspObject_Interface::copyDependenciesFromJaspObject,					"Will make the object depend on whatever the other jaspObject depends.")
-		.method("getError",							&	jaspObject_Interface::getError, 										"Get the error status of this object.")
-		.method("setError",							&	jaspObject_Interface::setError, 										"Set an error message on this object that which be shown in JASP. Errors set on jaspContainers or jaspResults are propagated to children, such that the first child shows the error and the others are greyed out.")
+		.method("setOptionMustBeDependency",			&	jaspObject_Interface::setOptionMustBeDependency,						"Specifies an option and it's required value, if the analysis is restarted and this option is no longer defined (like that) it will automatically destroy the object. Otherwise it will keep it.")
+		.method("setOptionMustContainDependency",		&	jaspObject_Interface::setOptionMustContainDependency,					"Specifies an option that should define an array and a required value that should be in it, if the analysis is restarted and this option is no longer defined or no longer contains the specified value it will automatically destroy the object. Otherwise it will keep it.")
+		.method("setNestedOptionMustContainDependency",	&	jaspObject_Interface::setNestedOptionMustContainDependency,				"Same as setOptionMustContainDependency but the input vector is treated as a vector of keys that indicate a nested option.")
+
+		.method("dependOnOptions",						&	jaspObject_Interface::dependOnOptions,									"Will make the object depend on the current values of the options specified in the charactervector.")
+		.method("dependOnNestedOptions",				&	jaspObject_Interface::dependOnNestedOptions,							"Same as dependOnOptions but the input vector is treated as a vector of keys that indicate a nested option.")
+		.method("copyDependenciesFromJaspObject",		&	jaspObject_Interface::copyDependenciesFromJaspObject,					"Will make the object depend on whatever the other jaspObject depends.")
+		.method("getError",								&	jaspObject_Interface::getError, 										"Get the error status of this object.")
+		.method("setError",								&	jaspObject_Interface::setError, 										"Set an error message on this object that which be shown in JASP. Errors set on jaspContainers or jaspResults are propagated to children, such that the first child shows the error and the others are greyed out.")
 	;
 
 	Rcpp::class_<jaspContainer_Interface>("jaspContainer")

--- a/src/jaspObject.cpp
+++ b/src/jaspObject.cpp
@@ -139,17 +139,11 @@ Json::Value jaspObject::getObjectFromNestedOption(std::vector<std::string> neste
 			obj = obj.get(index, Json::nullValue);
 		}
 		else
-		{
 			obj = obj.get(key, Json::nullValue);
-		}
 
-		if (obj.isNull()) {
-//			Rcpp::Rcout << "getObjectFromNestedOption fid not find key: " << key << std::endl;
+		if (obj.isNull())
 			return ifNotFound;
-		}
-//		else {
-//			Rcpp::Rcout << "getObjectFromNestedOption found key: " << key << std::endl;
-//		}
+
 	}
 	return obj;
 }
@@ -169,25 +163,27 @@ std::string jaspObject::nestedKeyToString(const std::vector<std::string> &nested
 
 std::vector<std::string> jaspObject::stringToNestedKey(const std::string &str, const std::string &sep) const
 {
-	std::string::size_type pos = 0;
+
 	std::vector<std::string> nestedKey;
 	size_t noKeys = 1;
 
-	while ((pos = str.find(sep, pos )) != std::string::npos)
+	std::string::size_type pos = 0;
+	while ((pos = str.find(sep, pos)) != std::string::npos)
 	{
 		noKeys++;
 		pos += sep.length();
 	}
 
 	nestedKey.reserve(noKeys);
-	std::string token;
 	pos = 0;
-	std::string s = str; // explicit copy to avoi modifying str
+	std::string s = str; // explicit copy to avoid modifying str
+	// Could also be done with 2 positions, e.g., s.substr(start, stop);
 	while ((pos = s.find(sep)) != std::string::npos)
 	{
 		nestedKey.push_back(s.substr(0, pos));
 		s.erase(0, pos + sep.length());
 	}
+	nestedKey.push_back(s);
 
 	return nestedKey;
 }
@@ -521,11 +517,8 @@ bool jaspObject::checkDependencies(Json::Value currentOptions)
 		}
 
 		for(auto & keyval : _nestedOptionMustBe)
-		{
-			Rcpp::Rcout << "Checking key " << nestedKeyToString(keyval.first) << std::endl;
 			if(getObjectFromNestedOption(keyval.first) != keyval.second)
 				return false;
-		}
 
 		for(auto & keyval : _nestedOptionMustContain)
 		{

--- a/src/jaspObject.cpp
+++ b/src/jaspObject.cpp
@@ -155,6 +155,7 @@ std::string jaspObject::nestedKeyToString(const std::vector<std::string> &nested
 
 	for (int i = 0; i < nestedKey.size() - 1; i++)
 		joined += nestedKey[i] + sep;
+
 	joined += nestedKey[nestedKey.size() - 1];
 
 	return joined;
@@ -447,15 +448,9 @@ void jaspObject::setOptionMustContainDependency(std::string optionName, Rcpp::RO
 void jaspObject::dependOnNestedOptions(Rcpp::CharacterVector nestedOptionName)
 {
 	std::vector<std::string> nestedKey = Rcpp::as<std::vector<std::string>>(nestedOptionName);
-
-//	Rcpp::Rcout << "dependOnNestedOptions received " << std::accumulate(nestedKey.begin(), nestedKey.end(), std::string("$")) << std::endl;
-
 	Json::Value obj = getObjectFromNestedOption(nestedKey);
 	if (obj.isNull())
-	{
-		std::string flattenedKey = std::accumulate(nestedKey.begin(), nestedKey.end(), std::string("$"));
-		Rf_error(("nested key \"" + flattenedKey + "\"does not exist in the options!").c_str());
-	}
+		Rf_error(("nested key \"" + nestedKeyToString(nestedKey, "$") + "\"does not exist in the options!").c_str());
 
 	_nestedOptionMustBe[nestedKey] = obj;
 }
@@ -466,15 +461,9 @@ void jaspObject::setNestedOptionMustContainDependency(Rcpp::CharacterVector nest
 		Rf_error("setOptionMustContainDependency expected not null!");
 
 	std::vector<std::string> nestedKey = Rcpp::as<std::vector<std::string>>(nestedOptionName);
-
-//	Rcpp::Rcout << "setNestedOptionMustContainDependency received " << std::accumulate(nestedKey.begin(), nestedKey.end(), std::string("$")) << std::endl;
-
 	Json::Value obj = getObjectFromNestedOption(nestedKey);
 	if (obj.isNull())
-	{
-		std::string flattenedKey = std::accumulate(nestedKey.begin(), nestedKey.end(), std::string("$"));
-		Rf_error(("nested key \"" + flattenedKey + "\"does not exist in the options!").c_str());
-	}
+		Rf_error(("nested key \"" + nestedKeyToString(nestedKey, "$") + "\"does not exist in the options!").c_str());
 
 	_nestedOptionMustContain[nestedKey] = RObject_to_JsonValue(mustContainThis);
 }

--- a/src/jaspObject.cpp
+++ b/src/jaspObject.cpp
@@ -366,7 +366,6 @@ Json::Value jaspObject::convertToJSON() const
 	for(auto & keyval : _optionMustContain)
 		obj["optionMustContain"][keyval.first] = keyval.second;
 
-	Rcpp::Rcout << "here" << std::endl;
 	obj["nestedOptionMustBe"]	= Json::objectValue;
 	for(auto & keyval : _nestedOptionMustBe)
 		obj["nestedOptionMustBe"][nestedKeyToString(keyval.first)] = keyval.second;
@@ -407,18 +406,15 @@ void jaspObject::convertFromJSON_SetFields(Json::Value in)
 	for(auto & mustContainKey : mustContain.getMemberNames())
 		_optionMustContain[mustContainKey] = mustContain[mustContainKey];
 
-	Rcpp::Rcout << "there 0" << std::endl;
 	_nestedOptionMustBe.clear();
 	Json::Value nestedMustBe(in.get("nestedOptionMustBe", Json::objectValue));
 	for(auto & nestedMustBeKey : nestedMustBe.getMemberNames())
 		_nestedOptionMustBe[stringToNestedKey(nestedMustBeKey)] = nestedMustBe[nestedMustBeKey];
 
-	Rcpp::Rcout << "there 1" << std::endl;
 	_nestedOptionMustContain.clear();
 	Json::Value nestedMustContain(in.get("nestedOptionMustContain", Json::objectValue));
 	for(auto & nestedMustContainKey : nestedMustContain.getMemberNames())
 		_nestedOptionMustContain[stringToNestedKey(nestedMustContainKey)] = nestedMustContain[nestedMustContainKey];
-	Rcpp::Rcout << "there 2" << std::endl;
 
 }
 

--- a/src/jaspObject.h
+++ b/src/jaspObject.h
@@ -55,6 +55,8 @@ public:
 
 			void		setOptionMustBeDependency(std::string optionName, Rcpp::RObject mustBeThis);
 			void		setOptionMustContainDependency(std::string optionName, Rcpp::RObject mustContainThis);
+			void		dependOnNestedOptions(Rcpp::CharacterVector nestedOptionName);
+			void		setNestedOptionMustContainDependency(Rcpp::CharacterVector nestedOptionName, Rcpp::RObject mustContainThis);
 			void		dependOnOptions(Rcpp::CharacterVector listOptions);
 			void		copyDependenciesFromJaspObject(jaspObject * other);
 
@@ -234,10 +236,12 @@ protected:
 	std::set<std::string>		_citations;
 	std::string					_name;
 
-	std::set<std::string>							nestedMustBes()			const;
-	std::map<std::string, std::set<std::string>>	nestedMustContains()	const;
-	std::map<std::string, Json::Value>				_optionMustContain;
-	std::map<std::string, Json::Value>				_optionMustBe;
+	std::set<std::string>								nestedMustBes()			const;
+	std::map<std::string, std::set<std::string>>		nestedMustContains()	const;
+	std::map<std::string, Json::Value>					_optionMustContain;
+	std::map<std::string, Json::Value>					_optionMustBe;
+	std::map<std::vector<std::string>, Json::Value>		_nestedOptionMustContain;
+	std::map<std::vector<std::string>, Json::Value>		_nestedOptionMustBe;
 
 
 //Should add dependencies somehow here?
@@ -256,6 +260,9 @@ protected:
 	static bool						_developerMode;
 
 private:
+
+	Json::Value getObjectFromNestedOption(std::vector<std::string> nestedKey, Json::Value ifNotFound = Json::nullValue) const;
+
 	bool					_finalizedAlready = false;
 };
 
@@ -334,11 +341,13 @@ public:
 	std::string	type()								{ return myJaspObject->type(); }
 	void		printHtml()							{ jaspPrint(myJaspObject->toHtml()); }
 
-	void		setOptionMustBeDependency(std::string optionName, Rcpp::RObject mustBeThis)				{ myJaspObject->setOptionMustBeDependency(optionName, mustBeThis);				}
-	void		setOptionMustContainDependency(std::string optionName, Rcpp::RObject mustContainThis)	{ myJaspObject->setOptionMustContainDependency(optionName, mustContainThis);	}
-	void		dependOnOptions(Rcpp::CharacterVector listOptions)										{ myJaspObject->dependOnOptions(listOptions);									}
-	void		copyDependenciesFromJaspObject(jaspObject_Interface * other)							{ myJaspObject->copyDependenciesFromJaspObject(other->myJaspObject);			}
-	void		addCitation(Rcpp::String fullCitation)													{ myJaspObject->addCitation(fullCitation);										}
+	void		setOptionMustBeDependency(std::string optionName, Rcpp::RObject mustBeThis)								{ myJaspObject->setOptionMustBeDependency(optionName, mustBeThis);					}
+	void		setOptionMustContainDependency(std::string optionName, Rcpp::RObject mustContainThis)					{ myJaspObject->setOptionMustContainDependency(optionName, mustContainThis);		}
+	void		dependOnNestedOptions(Rcpp::CharacterVector optionName)													{ myJaspObject->dependOnNestedOptions(optionName);									}
+	void		setNestedOptionMustContainDependency(Rcpp::CharacterVector optionName, Rcpp::RObject mustContainThis)	{ myJaspObject->setNestedOptionMustContainDependency(optionName, mustContainThis);	}
+	void		dependOnOptions(Rcpp::CharacterVector listOptions)														{ myJaspObject->dependOnOptions(listOptions);										}
+	void		copyDependenciesFromJaspObject(jaspObject_Interface * other)											{ myJaspObject->copyDependenciesFromJaspObject(other->myJaspObject);				}
+	void		addCitation(Rcpp::String fullCitation)																	{ myJaspObject->addCitation(fullCitation);											}
 
 	JASPOBJECT_INTERFACE_PROPERTY_FUNCTIONS_GENERATOR_NATIVE_STRING(jaspObject, _title,		Title)
 	JASPOBJECT_INTERFACE_PROPERTY_FUNCTIONS_GENERATOR_NATIVE_STRING(jaspObject, _info,		Info)

--- a/src/jaspObject.h
+++ b/src/jaspObject.h
@@ -261,7 +261,9 @@ protected:
 
 private:
 
-	Json::Value getObjectFromNestedOption(std::vector<std::string> nestedKey, Json::Value ifNotFound = Json::nullValue) const;
+	Json::Value					getObjectFromNestedOption(std::vector<std::string> nestedKey, Json::Value ifNotFound = Json::nullValue) const;
+	std::string					nestedKeyToString(const std::vector<std::string> & nestedKey, const std::string & sep = "$!_SEP_!$")	const;
+	std::vector<std::string>	stringToNestedKey(const std::string & nestedKey, const std::string & sep = "$!_SEP_!$")					const;
 
 	bool					_finalizedAlready = false;
 };

--- a/src/jaspObject.h
+++ b/src/jaspObject.h
@@ -264,6 +264,7 @@ private:
 	Json::Value					getObjectFromNestedOption(std::vector<std::string> nestedKey, Json::Value ifNotFound = Json::nullValue) const;
 	std::string					nestedKeyToString(const std::vector<std::string> & nestedKey, const std::string & sep = "$!_SEP_!$")	const;
 	std::vector<std::string>	stringToNestedKey(const std::string & nestedKey, const std::string & sep = "$!_SEP_!$")					const;
+	bool						isJsonSubArray(const Json::Value needle, const Json::Value haystack)									const;
 
 	bool					_finalizedAlready = false;
 };


### PR DESCRIPTION
Required for some changes I'm making to Jags and Quality Control.

@Kucharssim I'd appreciate your feedback on the R-interface!

For any jaspObject, you can do
```r
obj$dependOn(
  # previously available
  options=...
  optionsFromObject=...
  optionContainsValue...
  # new in this PR
  nestedOptions=...
  nestedOptionsContainsValue=...
)
```
For `nestedOptions`, either pass a single character vector, for example `nestedOptions = c("model", "3", "checkbox")` to add a dependency on `options[["model"]][[3]][["checkbox"]]`, or use a list of character vectors to specify multiple nested dependencies:
```r
obj$dependOn(nestedOptions = list(
  c("model", "3", "checkboxA"),
  c("model", "3", "checkboxB"),
))
```

For `nestedOptionsContainsValue` the idea is to pass a list of key-value pairs where odd indices are interpreted as keys and even indices as values. For example:
```r
obj$dependOn(nestedOptionsContainsValue = list(
  c("model", "3", "variableField"), # key
  "contNormal",                     # value
  c("model", "3", "variableField"), # key
  "contGamma"                       # value
)
```
For readability, we should recommend that people write this in two aligned columns:
```r
obj$dependOn(nestedOptionsContainsValue = list(
  # keys                            values
  c("model", "3", "variableField"), "contNormal",
  c("model", "3", "variableField"), "contGamma"
))
```
this interface is documented as comments in zzzWrappers.R