### PR TITLE
Only columnencoder.cpp and columntype must be compiled

### DIFF
--- a/configure
+++ b/configure
@@ -102,7 +102,7 @@ location of the parent directory (e.g., the default is '-I\"../inst/include/jasp
 fi
 
 SRC_SOURCES="$(cd src/ && ls *.cpp | tr '\n' ' ')"
-JASPCOLUMNENCODER_SOURCES="$(cd src/ && ls ${JASPCOLUMNENCODER_DIR}/*.cpp | tr '\n' ' ')"
+JASPCOLUMNENCODER_SOURCES="${JASPCOLUMNENCODER_DIR}/columnencoder.cpp ${JASPCOLUMNENCODER_DIR}/columntype.cpp"
 
 #add the define if JASP_R_INTERFACE_LIBRARY env var says anything at all
 if [ "${JASP_R_INTERFACE_LIBRARY}" != "" ]; then

--- a/configure.win
+++ b/configure.win
@@ -87,7 +87,7 @@ location of the parent directory (e.g., the default is '-I\"../inst/include/jasp
 fi
 
 SRC_SOURCES="$(cd src/ && ls *.cpp | tr '\n' ' ')"
-JASPCOLUMNENCODER_SOURCES="$(cd src/ && ls ${JASPCOLUMNENCODER_DIR}/*.cpp | tr '\n' ' ')"
+JASPCOLUMNENCODER_SOURCES="${JASPCOLUMNENCODER_DIR}/columnencoder.cpp ${JASPCOLUMNENCODER_DIR}/columntype.cpp"
 
 sed -e "s|@cppflags@|${PKG_CXXFLAGS}|" -e "s|@src_sources@|${SRC_SOURCES}|" -e "s|@jaspColumnEncoder_sources@|${JASPCOLUMNENCODER_SOURCES}|" src/Makevars.in > src/Makevars.win
 

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,6 +1,6 @@
-CXX_STD				= CXX17
+CXX_STD				= CXX20
 PKG_CXXFLAGS		= @cppflags@
-CXX17STD			= -std=c++17
+CXX20STD			= -std=c++2a
 
 # Include all C++ files in src/ and jaspColumnEncoder
 SOURCES=@src_sources@ @jaspColumnEncoder_sources@

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,6 +1,6 @@
-CXX_STD				= CXX11
+CXX_STD				= CXX17
 PKG_CXXFLAGS		= @cppflags@
-CXX11STD			= -std=c++11
+CXX17STD			= -std=c++17
 
 # Include all C++ files in src/ and jaspColumnEncoder
 SOURCES=@src_sources@ @jaspColumnEncoder_sources@


### PR DESCRIPTION
As jaspColumnEncoder submodule will soon disappear, and be added directly in Common (which will be also a submodule), jaspBase should not compile all classes in Common but only what is needed for columnencoder.

This fix is needed for https://github.com/jasp-stats/jasp-desktop/pull/4914

This fix is needed because jaspBase generates error when compiling all files from Common: apparently R uses gnu++14 (JASP uses c++17), and some classes from Common includes <filesystem> which generates error in c++14.