### PR TITLE
sample.kind = 'Rounding' is optional

### DIFF
--- a/R/common.R
+++ b/R/common.R
@@ -73,7 +73,11 @@ runJaspResults <- function(name, title, dataKey, options, stateKey, functionCall
   # if (identical(.Platform$OS.type, "windows"))
   #   compiler::enableJIT(0)
 
-  suppressWarnings(RNGkind(sample.kind = "Rounding"))  # R 3.6.0 changed its rng; this ensures that for the time being the results do not change
+  if(!isFALSE(.Options[["jaspLegacyRngKind"]])) {
+    rngKind <- RNGkind()
+    RNGkind(sample.kind = "Rounding")  # R 3.6.0 changed its rng; this ensures that for the time being the results do not change
+    on.exit(RNGkind(sample.kind = rngKind[[3]]), add = TRUE)
+  }
 
   jaspResultsCPP        <- loadJaspResults(name)
   jaspResultsCPP$title  <- title


### PR DESCRIPTION
This allows us to gradually deprecate the old RNG sampling without breaking everything at once.

Needs to go with https://github.com/jasp-stats/jaspTools/pull/34

See https://github.com/Kucharssim/jaspTestModule/tree/testRngKind for an example

