### PR TITLE
fix installing from renv

### DIFF
--- a/R/moduleInstall.R
+++ b/R/moduleInstall.R
@@ -38,7 +38,7 @@ installJaspModule <- function(modulePkg, libPathsToUse, moduleLibrary, repos, on
   # if that isnt the case the (module) installation fails obscurely with an error like "Error in if (eval(cond, envir = environment(dot))) return(eval(expr, envir = environment(dot))): the condition has length > 1"
   cmdConfigCC <- system2(c(renv:::R(),"CMD","config","CC"),stdout=TRUE,stderr=TRUE)
   if(length(cmdConfigCC) > 1)
-    (if (getOS() == "osx") stop else warning)(
+    stop(
 "R CMD config CC returns more than 1 line, this will break renv and thus your install.
 Most likely you are on mac and you should run `xcode-select --install` in a terminal.
 If that doesn't help or you aren't on a mac: feel free to open an issue at https://github.com/jasp-stats/jasp-issues/issues/new/choose

--- a/R/moduleInstall.R
+++ b/R/moduleInstall.R
@@ -38,12 +38,12 @@ installJaspModule <- function(modulePkg, libPathsToUse, moduleLibrary, repos, on
   # if that isnt the case the (module) installation fails obscurely with an error like "Error in if (eval(cond, envir = environment(dot))) return(eval(expr, envir = environment(dot))): the condition has length > 1"
   cmdConfigCC <- system2(c(renv:::R(),"CMD","config","CC"),stdout=TRUE,stderr=TRUE)
   if(length(cmdConfigCC) > 1)
-    stop(
-"R CMD config CC returns more than 1 line, this will break renv and thus your install. 
-Most likely you are on mac and you should run `xcode-select --install` in a terminal. 
+    (if (getOS() == "osx") stop else warning)(
+"R CMD config CC returns more than 1 line, this will break renv and thus your install.
+Most likely you are on mac and you should run `xcode-select --install` in a terminal.
 If that doesn't help or you aren't on a mac: feel free to open an issue at https://github.com/jasp-stats/jasp-issues/issues/new/choose
-  
-The output was: 
+
+The output was:
 ", paste0(cmdConfigCC, collapse="\n"), domain = NA)
 
   r <- getOption("repos")
@@ -125,7 +125,7 @@ installJaspModuleFromRenv <- function(modulePkg, libPathsToUse, moduleLibrary, r
   moduleInfo         <- getModuleInfo(modulePkg)
   correctlyInstalled <- installModulePkg(modulePkg, moduleLibrary, prompt, moduleInfo, cacheAble=cacheAble)
 
-  if (!isPkgArchive && correctlyInstalled)
+  if (!isModulePkgArchive(modulePkg) && correctlyInstalled)
     writeMd5Sums(modulePkg, moduleLibrary)
 
   renv::snapshot(


### PR DESCRIPTION
The construction

```r
if (!isModulePkgArchive(modulePkg) && correctlyInstalled)
  writeMd5Sums(modulePkg, moduleLibrary)
```
is also used inside `installJaspModuleFromDescription`. I'm probably the only one that noticed, but `isPkgArchive` never exists so `installJaspModuleFromRenv` was pretty broken.