### PR TITLE
Display R warnings

### DIFF
--- a/R/common.R
+++ b/R/common.R
@@ -111,15 +111,15 @@ runJaspResults <- function(name, title, dataKey, options, stateKey, functionCall
 
   # ensure an analysis always starts with a clean hashtable of computed jasp Objects
   emptyRecomputed()
+  emptyWarnings()
 
-  warnings <- list()
   analysisResult <-
     tryCatch(
-      expr=withCallingHandlers(expr=analysis(jaspResults=jaspResults, dataset=dataset, options=options), error=.addStackTrace, warning = function(w) warnings <<- c(warnings, list(w))),
+      expr=withCallingHandlers(expr=analysis(jaspResults=jaspResults, dataset=dataset, options=options), error=.addStackTrace, warning = .addWarnings),
       error=function(e) e,
       jaspAnalysisAbort=function(e) e
     )
-  .appendOutputFromR(jaspResults, warnings)
+  .appendOutputFromR(jaspResults)
 
   if (!jaspResultsCalledFromJasp()) {
 

--- a/R/common.R
+++ b/R/common.R
@@ -112,12 +112,14 @@ runJaspResults <- function(name, title, dataKey, options, stateKey, functionCall
   # ensure an analysis always starts with a clean hashtable of computed jasp Objects
   emptyRecomputed()
 
+  warnings <- list()
   analysisResult <-
     tryCatch(
-      expr=withCallingHandlers(expr=analysis(jaspResults=jaspResults, dataset=dataset, options=options), error=.addStackTrace),
+      expr=withCallingHandlers(expr=analysis(jaspResults=jaspResults, dataset=dataset, options=options), error=.addStackTrace, warning = function(w) warnings <<- c(warnings, list(w))),
       error=function(e) e,
       jaspAnalysisAbort=function(e) e
     )
+  .appendOutputFromR(jaspResults, warnings)
 
   if (!jaspResultsCalledFromJasp()) {
 

--- a/R/commonerrorcheck.R
+++ b/R/commonerrorcheck.R
@@ -46,24 +46,29 @@
   signalCondition(e)
 }
 
-.sendWarning <- function(w) {
-  # Sends warning w to an object `warnings` in the parent frame
-  warnings <<- c(warnings, list(w))
-}
-
 .appendOutputFromR <- function(container, warnings) {
+  # currently adds only warnings, do we also want messages or something?
   if(identical(warnings, list())) return()
-  
-  # Adds a warning element to a jaspContainer
-  warnings <- vapply(warnings, as.character, character(1))
-  warnings <- trimws(warnings)
-  text <- paste0("<li><div class='jasp-code'>", warnings, "</div></li>", collapse = "")
-  text <- paste0("<ul>", text, "</ul>")
 
   output <- createJaspContainer(title = gettext("Output from R"), initCollapsed = TRUE)
-  output[["__warnings__"]] <- createJaspHtml(title = gettext("Warnings"), text = text)
 
-  container[["__output__"]] <- output
+  # Adds a warning element to a jaspContainer
+  text <- vapply(warnings, function(w) {
+    # oh lord forgive me for the code I am about to write right now:
+    # as.character can produce special symbols that are used to render the text in a different format in the R console, so the warning may become unintelligible
+    # so instead we `cat()` the output which prints the formatted text
+    # and capture the output as text again (without formatting)
+    w <- capture.output(cat(as.character(w)))
+    w <- paste0(w, collapse = "<br>")
+    return(w)
+  }, character(1))
+
+  text <- paste0("<li><p class='jasp-code'>", text, "</p></li>", collapse = "")
+  text <- paste0("<ul>", text, "</ul>")
+
+  output[["warnings"]] <- createJaspHtml(title = gettext("Warnings"), text = text)
+
+  container[[".outputFromR"]] <- output
 }
 
 

--- a/R/commonerrorcheck.R
+++ b/R/commonerrorcheck.R
@@ -46,9 +46,15 @@
   signalCondition(e)
 }
 
-.appendOutputFromR <- function(container, warnings) {
+.addWarnings <- function(w) {
+  .internal[["warnings"]] <- c(.internal[["warnings"]], list(w))
+}
+
+.appendOutputFromR <- function(container) {
+  warnings <- .internal[["warnings"]]
+  # display only in developer mode
   # currently adds only warnings, do we also want messages or something?
-  if(identical(warnings, list())) return()
+  if (!getDeveloperMode() || identical(warnings, list())) return()
 
   output <- createJaspContainer(title = gettext("Output from R"), initCollapsed = TRUE)
 

--- a/R/commonerrorcheck.R
+++ b/R/commonerrorcheck.R
@@ -46,6 +46,26 @@
   signalCondition(e)
 }
 
+.sendWarning <- function(w) {
+  # Sends warning w to an object `warnings` in the parent frame
+  warnings <<- c(warnings, list(w))
+}
+
+.appendOutputFromR <- function(container, warnings) {
+  if(identical(warnings, list())) return()
+  
+  # Adds a warning element to a jaspContainer
+  warnings <- vapply(warnings, as.character, character(1))
+  warnings <- trimws(warnings)
+  text <- paste0("<li><div class='jasp-code'>", warnings, "</div></li>", collapse = "")
+  text <- paste0("<ul>", text, "</ul>")
+
+  output <- createJaspContainer(title = gettext("Output from R"), initCollapsed = TRUE)
+  output[["__warnings__"]] <- createJaspHtml(title = gettext("Warnings"), text = text)
+
+  container[["__output__"]] <- output
+}
+
 
 .generateErrorMessage <- function(type, opening=FALSE, concatenate=NULL, grouping=NULL, ...) {
   # Generic function to create an error message (mostly used by .hasErrors() but it can be called directly).

--- a/R/setOrRetrieve.R
+++ b/R/setOrRetrieve.R
@@ -2,7 +2,8 @@
   # It's not 100% clear if "address" is the best choice here, but it should be a little bit faster than constructing hashes using identical.
   #  See also https://github.com/wch/r-source/blob/trunk/src/library/utils/src/hashtab.c
   recomputedHashtab = hashtab(type = "address", NULL),
-  lastRecomputed    = TRUE
+  lastRecomputed    = TRUE,
+  warnings          = list()
 ), parent = emptyenv())
 
 saveHashOfJaspObject <- function(x) {
@@ -18,6 +19,10 @@ emptyRecomputed <- function() {
   clrhash(.internal[["recomputedHashtab"]])
   # set lastRecomputed to TRUE
   setRecomputed(TRUE)
+}
+
+emptyWarnings <- function() {
+  .internal[["warnings"]] <- list()
 }
 
 #' Set or retrieve a jaspObject

--- a/src/jaspModuleRegistration.h
+++ b/src/jaspModuleRegistration.h
@@ -37,6 +37,7 @@ RCPP_MODULE(jaspResults)
 	Rcpp::function("writeSealFilename",					jaspResults::writeSealFilename);
 	Rcpp::function("setResponseData",					jaspResults::setResponseData);
 	Rcpp::function("setDeveloperMode",					jaspResults::setDeveloperMode);
+	Rcpp::function("getDeveloperMode",					jaspResults::getDeveloperMode);
 	Rcpp::function("setSaveLocation",					jaspResults::setSaveLocation);
 	Rcpp::function("setWriteSealLocation",				jaspResults::setWriteSealLocation);
 

--- a/src/jaspObject.cpp
+++ b/src/jaspObject.cpp
@@ -580,6 +580,11 @@ void jaspObject::setDeveloperMode(bool developerMode)
 	_developerMode = developerMode;
 }
 
+bool jaspObject::getDeveloperMode()
+{
+	return _developerMode;
+}
+
 bool jaspObject::connectedToJaspResults()
 {
 

--- a/src/jaspObject.h
+++ b/src/jaspObject.h
@@ -130,6 +130,7 @@ public:
 
 	static int getCurrentTimeMs();
 	static void setDeveloperMode(bool developerMode);
+	static bool getDeveloperMode();
 
 	bool			connectedToJaspResults();
 


### PR DESCRIPTION
fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2138

It's kind of a hacky quick fix but it works nicely so why not?

Two questions regarding the implementation:

1. The warnings are also caught and displayed if we run the analysis from `jaspTools` (which also "cleans up" the output in our unit tests). The question is whether we want to do that since perhaps it's valuable to see all warnings in the testing output?
2. The only warnings that are displayed are those that occurred during the most recent analysis run. So if a particular code produced a warning but it's not run anymore because its output is saved in a state, it will dissapear from that list. Do we want to have a persistent (within an analysis) and ever growing list of warnings instead?