### PR TITLE
Clean up `on.exit` statements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,7 @@ Description: Package contains the JASP Bayesian and Frequentist analyses.
     See <https://jasp-stats.org> for more details.
 License: GPL2+
 Imports:
+  cli,
   codetools,
   compiler,
   ggplot2,

--- a/R/utility.R
+++ b/R/utility.R
@@ -34,7 +34,9 @@ restoreOptions <- function(oldOptions) {
 
   newOptions <- options()
   oldOptions[setdiff(names(newOptions), names(oldOptions))] <- list(NULL)
-  options(oldOptions)
+  # resetting 'nwarnings' resets the collection of warnings, so it may remove warnings that occur in any parent function
+  # so we do not reset 'nwarnings'
+  options(oldOptions[setdiff(names(oldOptions), "nwarnings")])
 
 }
 

--- a/R/utility.R
+++ b/R/utility.R
@@ -72,13 +72,12 @@ legacyRngWarning <- function() {
 
   cli::cli_warn(
     message = c(
-      "!" = "Legacy {default} is used by default.",
-      "i" = "To use the current {rngKind} setting instead, use {suggestion}."
+      "!" = "Legacy `{default}` is used by default.",
+      "i" = "To use the current `{rngKind}` setting instead, use `{suggestion}`."
     ),
     class = "jaspBaseWarning",
-    footer = cli::col_silver("This warning is displayed once every 8 hours."),
-    frequency    = "regularly", # show this warning once every 8 hours
-    frequency_id = "legacyRngWarning"
+    .frequency    = "regularly", # show this warning once every 8 hours
+    .frequency_id = "legacyRngWarning"
   )
   return()
 }

--- a/R/utility.R
+++ b/R/utility.R
@@ -54,7 +54,7 @@ setOptionsCleanupHook <- function() {
 setLegacyRng <- function() {
   # R 3.6.0 changed its rng; this ensures that for the time being the results do not change
   # Unless we request to use the current method explicitly with options(jaspLegacyRngKind = FALSE)
-  if(isFALSE(.Options[["jaspLegacyRngKind"]])) return()
+  if(getOption("jaspLegacyRngKind", default = TRUE)) return()
 
 
   rngKind <- RNGkind()


### PR DESCRIPTION
Resetting `nwarnings` cleans up the collection of warnings in R, so when we did that we also inadvertently suppressed all warnings.

I also added some fixes to `on.exit` calls some of which did not use `add = TRUE` and so cancelled each other out. Now we use `withr::defer()` so this is avoided.

I also improved setting the legacy seed options and used `cli_warn` so that we do not clutter unit tests with this warning. 