### PR TITLE
remove calls to `.v` and `.unv` inside jaspBase

### DIFF
--- a/R/common.R
+++ b/R/common.R
@@ -357,7 +357,7 @@ isTryError <- function(obj){
   if (is.null(new.df))
     return (data.frame())
 
-  names(new.df) <- .v(namez)
+  names(new.df) <- namez
 
   new.df <- .excludeNaListwise(new.df, exclude.na.listwise)
 
@@ -370,7 +370,7 @@ isTryError <- function(obj){
 
     rows.to.exclude <- c()
 
-    for (col in .v(exclude.na.listwise))
+    for (col in exclude.na.listwise)
       rows.to.exclude <- c(rows.to.exclude, which(is.na(dataset[[col]])))
 
     rows.to.exclude <- unique(rows.to.exclude)
@@ -399,7 +399,7 @@ isTryError <- function(obj){
   f  <- rm.factors[[length(rm.factors)]]
   df <- data.frame(factor(unlist(f$levels), unlist(f$levels)))
 
-  names(df) <- .v(f$name)
+  names(df) <- f$name
 
   row.count <- dim(df)[1]
 
@@ -425,12 +425,12 @@ isTryError <- function(obj){
     cells <- factor(cells, unlist(f$levels))
 
     df <- cbind(cells, df)
-    names(df)[[1]] <- .v(f$name)
+    names(df)[[1]] <- f$name
 
     i <- i - 1
   }
 
-  ds <- subset(dataset, select=.v(rm.vars))
+  ds <- subset(dataset, select=rm.vars)
   ds <- t(as.matrix(ds))
 
   dependentDf <- data.frame(x = as.numeric(c(ds)))
@@ -439,9 +439,9 @@ isTryError <- function(obj){
 
   for (bt.var in bt.vars) {
 
-    cells <- rep(dataset[[.v(bt.var)]], each=row.count)
+    cells <- rep(dataset[[bt.var]], each=row.count)
     new.col <- list()
-    new.col[[.v(bt.var)]] <- cells
+    new.col[[bt.var]] <- cells
 
     df <- cbind(df, new.col)
   }

--- a/R/commonerrorcheck.R
+++ b/R/commonerrorcheck.R
@@ -372,7 +372,7 @@
   for (v in target) {
 
     if (is.factor(dataset[[v]])) { # Coerce factor to numeric.
-      dataset[[v]] <- as.numeric(as.character(dataset[[v]])
+      dataset[[v]] <- as.numeric(as.character(dataset[[v]]))
     }
 
     if (length(grouping) > 0 && length(groupingLevel) > 0) {

--- a/R/commonerrorcheck.R
+++ b/R/commonerrorcheck.R
@@ -211,7 +211,7 @@
         # See if this check expects target variables and if they were provided, if not add all variables.
         funcTargetVars <- paste0(type[[i]], '.target')
         if (funcTargetVars %in% names(funcArgs) && !funcTargetVars %in% names(args))
-          args[[funcTargetVars]] <- .unv(names(dataset))
+          args[[funcTargetVars]] <- names(dataset)
 
         # Obtain an overview of required and optional check arguments.
         optArgs <- list()
@@ -332,14 +332,14 @@
       }, character(1))
     }
 
-    expr <- paste(.v(grouping), levels, sep='==', collapse='&')
+    expr <- paste(grouping, levels, sep='==', collapse='&')
     dataset <- subset(dataset, eval(parse(text=expr)))
-    result <- func(dataset[[.v(target)]])
+    result <- func(dataset[[target]])
 
   } else {
 
-    vgrouping <- .v(grouping)
-    vtarget   <- .v(target)
+    vgrouping <- grouping
+    vtarget   <- target
 
     result <- plyr::ddply(dataset, vgrouping,
       function(data, vtarget) {
@@ -371,14 +371,14 @@
 
   for (v in target) {
 
-    if (is.factor(dataset[[.v(v)]])) { # Coerce factor to numeric.
-      dataset[[.v(v)]] <- as.numeric(as.character(dataset[[.v(v)]]))
+    if (is.factor(dataset[[v]])) { # Coerce factor to numeric.
+      dataset[[v]] <- as.numeric(as.character(dataset[[v]])
     }
 
     if (length(grouping) > 0 && length(groupingLevel) > 0) {
       hasInf <- .applyOnGroups(findInf, dataset, v, grouping, groupingLevel)
     } else { # Makes no sense to check all subgroups for infinity rather than the entire variable at once.
-      hasInf <- findInf(dataset[[.v(v)]])
+      hasInf <- findInf(dataset[[v]])
     }
 
     if (hasInf) {
@@ -402,7 +402,7 @@
 
   for (v in target) {
 
-    levelsOfVar <- length(unique(na.omit(dataset[[.v(v)]])))
+    levelsOfVar <- length(unique(na.omit(dataset[[v]])))
     for (checkAmount in amount) {
       expr <- paste(levelsOfVar, checkAmount)
       if (eval(parse(text=expr))) {
@@ -442,7 +442,7 @@
     if (length(grouping) > 0) {
       variance <- .applyOnGroups(getVariance, dataset, v, grouping, groupingLevel)
     } else {
-      variance <- getVariance(dataset[[.v(v)]])
+      variance <- getVariance(dataset[[v]])
     }
 
     if (any(variance == equalTo)) {
@@ -475,7 +475,7 @@
     if (length(grouping) > 0) {
       obs <- .applyOnGroups(getObservations, dataset, v, grouping, groupingLevel)
     } else {
-      obs <- getObservations(dataset[[.v(v)]])
+      obs <- getObservations(dataset[[v]])
     }
 
     for (checkAmount in amount) {
@@ -501,7 +501,7 @@
   #   groupingLevel: Vector indicating the level of each of the grouping variables.
   result <- list(error=FALSE, errorVars=NULL)
 
-  dataPairs <- dataset[, .v(target)]
+  dataPairs <- dataset[, target]
 
   if (sum(!apply(dataPairs, 1, function(x){any(is.na(x))})) <= amount) { # See if any of the expressions is true.
     result$error <- TRUE
@@ -565,7 +565,7 @@
 
   for (v in target) {
 
-    rangeOfVar <- range(na.omit(dataset[[.v(v)]]))
+    rangeOfVar <- range(na.omit(dataset[[v]]))
 
     if (rangeOfVar[1] < min || rangeOfVar[2] > max) {
       result$error <- TRUE
@@ -592,10 +592,10 @@
     corFun <- stats::cor
 
   if (is.null(grouping)) {
-    dataset <- list(dataset[, .v(target)])
+    dataset <- list(dataset[, target])
   } else {
-    groupingData <- dataset[, .v(grouping)]
-    dataset <- dataset[, .v(target)]
+    groupingData <- dataset[, grouping]
+    dataset <- dataset[, target]
     dataset <- split(dataset, groupingData)
   }
   for (d in seq_along(dataset)) {
@@ -663,14 +663,14 @@
 
   for (v in target) {
 
-    if (is.factor(dataset[[.v(v)]])) { # Coerce factor to numeric.
-      dataset[[.v(v)]] <- as.numeric(as.character(dataset[[.v(v)]]))
+    if (is.factor(dataset[[v]])) { # Coerce factor to numeric.
+      dataset[[v]] <- as.numeric(as.character(dataset[[v]]))
     }
 
     if (length(grouping) > 0 && length(groupingLevel) > 0) {
       hasNegativeValues <- .applyOnGroups(findNegativeValues, dataset, v, grouping, groupingLevel)
     } else {
-      hasNegativeValues <- findNegativeValues(dataset[[.v(v)]])
+      hasNegativeValues <- findNegativeValues(dataset[[v]])
     }
 
     if (hasNegativeValues) {
@@ -702,7 +702,7 @@
     if (length(grouping) > 0 && length(groupingLevel) > 0) {
       hasMissingValues <- .applyOnGroups(findMissingValues, dataset, v, grouping, groupingLevel)
     } else {
-      hasMissingValues <- findMissingValues(dataset[[.v(v)]])
+      hasMissingValues <- findMissingValues(dataset[[v]])
     }
 
     if (hasMissingValues) {
@@ -744,7 +744,7 @@
   if (is.null(target)) {
     targetB64 <- colnames(dataset)
   } else {
-    targetB64 <- .v(target)
+    targetB64 <- target
   }
 
   if (length(target) > 1L) {
@@ -752,7 +752,7 @@
     if (is.null(grouping)) {
       dataset <- list(dataset[, targetB64])
     } else {
-      groupingData <- dataset[, .v(grouping)]
+      groupingData <- dataset[, grouping]
       dataset <- dataset[, targetB64]
       dataset <- split(dataset, groupingData)
     }


### PR DESCRIPTION
I see this one a bit too often:

![image](https://user-images.githubusercontent.com/21319932/205903645-ad998afa-ab7d-4427-95c1-4c07093114ce.png)

so I figured, let's just remove the `.v` and `.unv` calls.
I did not try to clean up any of the code, so there are some things that may look a little bit odd now. For example, `targetB64 <- target`. Let's leave cleaning that up for another time.