### PR TITLE
Fix setOrRetrieve and jaspDeps

### DIFF
--- a/R/jaspDeps.R
+++ b/R/jaspDeps.R
@@ -37,14 +37,3 @@ jaspDeps <- function(options = NULL, optionsFromObject = NULL, optionContainsVal
 is.jaspDeps <- function(x) {
   inherits(x, "jaspDeps")
 }
-
-setJaspDeps <- function(jaspObj, jaspDeps) {
-  jaspObj$dependOn(
-    options                    = jaspDeps[["options"]],
-    optionsFromObject          = jaspDeps[["optionsFromObject"]],
-    optionContainsValue        = jaspDeps[["optionContainsValue"]],
-    nestedOptions              = jaspDeps[["nestedOptions"]],
-    nestedOptionsContainsValue = jaspDeps[["nestedOptionsContainsValue"]]
-  )
-  return(jaspObj)
-}

--- a/R/setOrRetrieve.R
+++ b/R/setOrRetrieve.R
@@ -87,6 +87,8 @@ emptyRecomputed <- function() {
   if (length(exprLhs) != 3L || !identical(as.character(exprLhs[[1L]]), "[["))
     stop("The parent of the left-hand side of %setOrRetrieve% is not indexing with `[[` in a jaspObject!", domain = NA)
 
+  # for nested objects, e.g., `container[["a"]][["b"]]` this will retrieve `container[["a"]]`
+  # requires `envir = parent.frame(2L)` because the parent jaspObject does not exist in this functions environment
   parentObjectLhs <- eval(exprLhs[[2L]], envir = parent.frame(2L))
   if (!is.jaspObjR(parentObjectLhs))
     stop("The parent of the left-hand side of %setOrRetrieve% (", as.character(exprLhs[[2L]]), ") did not return a jaspObject!", domain = NA)
@@ -98,7 +100,8 @@ emptyRecomputed <- function() {
     stop("The right hand side of `%setOrRetrieve%` should evaluate to a jaspObject but it got an object of class ",
          paste(class(result), collapse = ""), domain = NA)
 
-  expr <- call("<-", exprLhs, as.name("result"))
+  expr <- call("<-", exprLhs, result) # the literal result
+  # assign the result in the calling environment because otherwise the parent jaspObject cannot be found.
   eval(expr, envir = parent.frame(2L))
 
   if (is.jaspStateR(result))

--- a/R/setOrRetrieve.R
+++ b/R/setOrRetrieve.R
@@ -87,7 +87,7 @@ emptyRecomputed <- function() {
   if (length(exprLhs) != 3L || !identical(as.character(exprLhs[[1L]]), "[["))
     stop("The parent of the left-hand side of %setOrRetrieve% is not indexing with `[[` in a jaspObject!", domain = NA)
 
-  parentObjectLhs <- eval(exprLhs[[2L]])
+  parentObjectLhs <- eval(exprLhs[[2L]], envir = parent.frame(2L))
   if (!is.jaspObjR(parentObjectLhs))
     stop("The parent of the left-hand side of %setOrRetrieve% (", as.character(exprLhs[[2L]]), ") did not return a jaspObject!", domain = NA)
 
@@ -99,7 +99,7 @@ emptyRecomputed <- function() {
          paste(class(result), collapse = ""), domain = NA)
 
   expr <- call("<-", exprLhs, as.name("result"))
-  eval(expr)
+  eval(expr, envir = parent.frame(2L))
 
   if (is.jaspStateR(result))
     return(result$object)


### PR DESCRIPTION
I was trying out our shiny new feature in jasp and noticed it's completely broken...

- `parentObjectLhs <- eval(exprLhs[[2L]])` does not work without `envir = parent.frame(2L)`. This does work in the global environment but not inside functions I guess.
- `setJaspDeps` did not work at all, because it was called with the c++ objects and not the R6 wrappers. I fixed this by explicitly calling `super$dependOn(dependencies)`. For this to work we need to assign the jaspObject to private$jaspObject first because that's what `jaspObj$dependOn(...)` references.