### PR TITLE
fix dependencies set through optionContainsValue

### DIFF
--- a/src/jaspObject.cpp
+++ b/src/jaspObject.cpp
@@ -218,7 +218,7 @@ bool jaspObject::isJsonSubArray(const Json::Value needles, const Json::Value hay
 				return false;
 		}
 	}
-	else // haystack must be an array
+	else // haystack must be an array and needles a single value
 	{
 		bool foundIt = false;
 		for (const auto & hay : haystack)

--- a/src/jaspObject.cpp
+++ b/src/jaspObject.cpp
@@ -199,11 +199,30 @@ bool jaspObject::isJsonSubArray(const Json::Value needles, const Json::Value hay
 	if (needles == haystack)
 		return true;
 
-	for (const auto & needle: needles)
+	if (!(needles.isArray() || haystack.isArray()) || (needles.isArray() && !haystack.isArray()))
+		return false;
+
+	if (needles.isArray())
+	{
+		for (const auto & needle: needles)
+		{
+			bool foundIt = false;
+			for (const auto & hay : haystack)
+				if (needle == hay)
+				{
+					foundIt = true;
+					break;
+				}
+
+			if (!foundIt)
+				return false;
+		}
+	}
+	else // haystack must be an array
 	{
 		bool foundIt = false;
 		for (const auto & hay : haystack)
-			if (needle == hay)
+			if (needles == hay)
 			{
 				foundIt = true;
 				break;


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2204

I incorrectly assumed that single values are iterable (like in R), that is if `needles` is not an array value then
```c++
for (const auto & needle: needles)
```
will loop once and the value of `needle` is identical to `needles`. However, this is not true, when needles is not an array value the range for loop is skipped. In that case, the original code skipped the loop entirely and we always returned true whenever `needles.isArray()` returned false and the haystack wasn't empty :upside_down_face: 

There is some duplication of code here, the cases where needles is an array vs non-array have a very similar loop, but I'm not entirely sure how to avoid it.
