### PR TITLE
Do not use tabs in Makevars files when specifying C++20

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,6 +1,5 @@
-CXX_STD				= CXX20
-PKG_CXXFLAGS		= @cppflags@
-CXX20STD			= -std=c++2a
+CXX_STD = CXX20
+PKG_CXXFLAGS = @cppflags@
 
 # Include all C++ files in src/ and jaspColumnEncoder
 SOURCES=@src_sources@ @jaspColumnEncoder_sources@


### PR DESCRIPTION
`CXX20STD` should be set by `CXX_STD` automatically. But if we use tabs then `CXX_STD` is ignored entirely, at least on Linux.

@boutinb can you check that this doesn't break anything on mac?
