### PR TITLE
add forgotten method for 'Rcpp_jaspQmlSource' to jaspCppToR6

### DIFF
--- a/R/zzzWrappers.R
+++ b/R/zzzWrappers.R
@@ -484,6 +484,7 @@ jaspContainerR <- R6::R6Class(
         "Rcpp_jaspColumn"    = jaspColumnR$new(    jaspObject = cppObj ),
         "Rcpp_jaspState"     = jaspStateR$new(     jaspObject = cppObj ),
         "Rcpp_jaspHtml"      = jaspHtmlR$new(      jaspObject = cppObj ),
+        "Rcpp_jaspQmlSource" = jaspQmlSourceR$new(jaspObject = cppObj  ),
 		    "Rcpp_jaspReport"    = jaspReportR$new(    jaspObject = cppObj ),
         stop(sprintf("Invalid call to jaspCppToR6. Expected jaspResults object but got %s", class(cppObj)), domain = NA)
       ))


### PR DESCRIPTION
@boutinb this should fix the issue you mentioned over slack:

![image](https://user-images.githubusercontent.com/21319932/226538700-fb38d601-88b5-4a9b-8ce3-c6674a4875d6.png)
