### PR TITLE
Dont catch warnings in loading of state as it breaks the state

### DIFF
--- a/R/common.R
+++ b/R/common.R
@@ -538,8 +538,8 @@ jaspResultsStrings <- function() {
 
     base::tryCatch(
       base::load(location$relativePath),
-      error=function(e) e,
-      warning=function(w) w
+      error=function(e) e
+      #,warning=function(w) w #Commented out because if there *is* a warning, which there of course shouldnt be, the state wont be loaded *at all*. 
     )
   }
 


### PR DESCRIPTION
Was made to mitigate https://github.com/jasp-stats/jasp-test-release/issues/2347 (plotobject missing on jaspfile load and image resize)

but this is already fixed better in https://github.com/jasp-stats/jasp-desktop/pull/5193

However, apparently any warning during loading state could break loading state if we catch it... So this is probably still a good idea to merge