### PR TITLE
Use testthat

### DIFF
--- a/.github/workflows/downstream-tests-on-comment.yml
+++ b/.github/workflows/downstream-tests-on-comment.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        r: [4.2.1]
+        r: [4.3.1]
         os: [ubuntu-latest, macOS-latest, windows-latest]
         # only common modules
         module: [jasp-stats/jaspDescriptives, jasp-stats/jaspTTests, jasp-stats/jaspAnova, jasp-stats/jaspRegression, jasp-stats/jaspFrequencies, jasp-stats/jaspFactor]

--- a/.github/workflows/rcmdcheck.yml
+++ b/.github/workflows/rcmdcheck.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        r: [4.2.1]
+        r: [4.3.1]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     env:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,3 +43,6 @@ Encoding: UTF-8
 LinkingTo: Rcpp
 RcppModules: jaspResults
 NeedsCompilation: yes
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(jaspBase)
+
+test_check("jaspBase")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -9,4 +9,4 @@
 library(testthat)
 library(jaspBase)
 
-test_check("jaspBase")
+test_check("jaspBase", reporter = NULL)

--- a/tests/testthat/test-transformFunctions.R
+++ b/tests/testthat/test-transformFunctions.R
@@ -1,0 +1,34 @@
+testthat::test_that("fisher Z works", {
+  r <- seq(-1, 1, by = 0.1)
+  testthat::expect_equal(
+    object = fishZ(r) |> invFishZ(),
+    expected = r)
+})
+
+testthat::test_that("Power transforms work", {
+  x <- seq(-1, 10, by = 1)
+  testthat::expect_equal(
+    object = BoxCox(x, lambda = 2, shift = 2) |> invBoxCox(lambda = 2, shift = 2),
+    expected = x)
+
+  testthat::expect_equal(
+    object = powerTransform(x, lambda = 0.5, shift = 1),
+    expected = c(NA, 0, 0.37389291204479, 0.6607910340708, 0.902657339133702,
+                 1.11574583155834, 1.30839255432226, 1.48554949932136, 1.65044316322328,
+                 1.8053146782674, 1.95179579919584, 2.09111836903338))
+
+  testthat::expect_equal(
+    object = YeoJohnson(x, lambda = 1.32),
+    expected = c(-0.885499639969477, 0, 1.13383416500244, 2.47259978867969,
+                 3.96463381612424, 5.5820916507262, 7.30707786783549, 9.12694190110795,
+                 11.032181180755, 13.0153492011314, 15.0704252337427, 17.1924226010993)
+  )
+})
+
+testthat::test_that("Logit transform works", {
+  p <- seq(0, 1, by = 0.1)
+  testthat::expect_equal(
+    object = logit(p) |> invLogit(),
+    expected = p
+  )
+})


### PR DESCRIPTION
While working on https://github.com/jasp-stats/INTERNAL-jasp/issues/2332, I need to write tests because otherwise I drown trying to make sure I cover all functionality and corner cases.

This PR only enables `testthat` for this repo and adds just a few tests for already existing functionality. The tests are run automatically as part of the R-CMD-CHECK action.