### PR TITLE
Change parent environment of setOrRetrieve

### DIFF
--- a/R/setOrRetrieve.R
+++ b/R/setOrRetrieve.R
@@ -89,7 +89,7 @@ emptyRecomputed <- function() {
 
   # for nested objects, e.g., `container[["a"]][["b"]]` this will retrieve `container[["a"]]`
   # requires `envir = parent.frame(2L)` because the parent jaspObject does not exist in this functions environment
-  parentObjectLhs <- eval(exprLhs[[2L]], envir = parent.frame(2L))
+  parentObjectLhs <- eval(exprLhs[[2L]], envir = parent.frame(1L))
   if (!is.jaspObjR(parentObjectLhs))
     stop("The parent of the left-hand side of %setOrRetrieve% (", as.character(exprLhs[[2L]]), ") did not return a jaspObject!", domain = NA)
 
@@ -102,7 +102,7 @@ emptyRecomputed <- function() {
 
   expr <- call("<-", exprLhs, result) # the literal result
   # assign the result in the calling environment because otherwise the parent jaspObject cannot be found.
-  eval(expr, envir = parent.frame(2L))
+  eval(expr, envir = parent.frame(1L))
 
   if (is.jaspStateR(result))
     return(result$object)


### PR DESCRIPTION
I am not sure anymore if this was intentional, but currently `%setOrRetrieve%` uses `parent.frame(2L)`, which prohibits chaining `%setOrRetrieve%` inside of `R` functions like this:

```R
library(jaspBase)

# otherwise jaspState crashes badly (should be fixed another time)
jaspResultsCPP        <- jaspBase:::loadJaspResults("a name")
jaspResultsCPP$title  <- "a title"
jaspResults           <- jaspBase:::jaspResultsR$new(jaspResultsCPP)

analysis <- function(jaspResults) {
  topContainer <- jaspResults[["topContainer"]] %setOrRetrieve%
    jaspBase::createJaspContainer(title = gettext("Top container"))
  
  subContainer <- topContainer[["subContainer"]] %setOrRetrieve%
    jaspBase::createJaspContainer(title = gettext("Sub container"))
  return(topContainer)
}

analysis(jaspResults)
```

Of course, you could avoid this if you replace 

```R
subContainer <- topContainer[["subContainer"]] %setOrRetrieve%
```

with 

```R
subContainer <- jaspResults[["topContainer"]][["subContainer"]] %setOrRetrieve%
```

but then there is no reason for creating the `topContainer` object in the first place if we still require to call the `jaspResults` object to obtain the top container anyway.

Alternatively, you can put `subContainer` creation into a separate function, which would mean that `topContainer` is indeed inside of `parent.frame(2L)`. However, I don't think it's a bad practice to let developers chain these statements in a single environment if they want to. @vandenman or did do this to avoid possible side-effects or something?