### PR TITLE
Fix building failure with `-Werror=format-security`

### DIFF
--- a/src/jaspObject.cpp
+++ b/src/jaspObject.cpp
@@ -492,7 +492,7 @@ void jaspObject::dependOnNestedOptions(Rcpp::CharacterVector nestedOptionName)
 	std::vector<std::string> nestedKey = Rcpp::as<std::vector<std::string>>(nestedOptionName);
 	Json::Value obj = getObjectFromNestedOption(nestedKey);
 	if (obj.isNull())
-		Rf_error(("nested key \"" + nestedKeyToString(nestedKey, "$") + "\"does not exist in the options!").c_str());
+		Rf_error("nested key `%s` does not exist in the options!", nestedKeyToString(nestedKey, "$").c_str());
 
 	_nestedOptionMustBe[nestedKey] = obj;
 }
@@ -505,7 +505,7 @@ void jaspObject::setNestedOptionMustContainDependency(Rcpp::CharacterVector nest
 	std::vector<std::string> nestedKey = Rcpp::as<std::vector<std::string>>(nestedOptionName);
 	Json::Value obj = getObjectFromNestedOption(nestedKey);
 	if (obj.isNull())
-		Rf_error(("nested key \"" + nestedKeyToString(nestedKey, "$") + "\"does not exist in the options!").c_str());
+		Rf_error("nested key `%s` does not exist in the options!", nestedKeyToString(nestedKey, "$").c_str());
 
 	_nestedOptionMustContain[nestedKey] = RObject_to_JsonValue(mustContainThis);
 }

--- a/src/jaspResults.cpp
+++ b/src/jaspResults.cpp
@@ -49,7 +49,7 @@ void jaspResults::setResponseData(int analysisID, int revision)
 
 	_response["id"]			= analysisID;
 	_response["revision"]	= revision;
-	
+
 	Json::Value progress;
 	progress["value"]		= -1;
 	progress["label"]		= "";
@@ -203,9 +203,7 @@ void jaspResults::saveResults()
 
 	if(!saveHere.good())
 	{
-		static std::string error;
-		error = "Could not open file for saving jaspResults! File: '" + _saveResultsRoot + _saveResultsHere + "'";
-		Rf_error(error.c_str());;
+		Rf_error("Could not open file for saving jaspResults! File: '%s%s'", _saveResultsRoot.c_str(), _saveResultsHere.c_str());;
 	}
 
 	Json::Value json = convertToJSON();
@@ -254,9 +252,7 @@ void jaspResults::loadResults()
 
 	if(!val.isObject())
 	{
-		static std::string error;
-		error = "loading jaspResults had a problem, '" + _saveResultsRoot + _saveResultsHere + "' wasn't a JSON object!";
-		Rf_error(error.c_str());;
+		Rf_error("loading jaspResults had a problem, '%s%s' wasn't a JSON object!", _saveResultsRoot.c_str(), _saveResultsHere.c_str());;
 	}
 
 	convertFromJSON_SetFields(val);


### PR DESCRIPTION
Archlinux enables `-Werror=format-security` by default, which causes jaspBase failed to be built. This pr fix it.
Here is a [relevant log](https://build.bioarchlinux.org/api/pkg/r-jaspbase/log/1714092710) (at the bottom of the page).