### PR TITLE
Run R cmd check for current release and devel version

### DIFF
--- a/.github/workflows/rcmdcheck.yml
+++ b/.github/workflows/rcmdcheck.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        r: [4.3.1]
+        r: [4.4.0, release, devel]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     env:
@@ -35,6 +35,7 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           error-on: '"error"'
+          needs: check
 
       - name: Show testthat output
         if: always()


### PR DESCRIPTION
to check compiling error early for upcoming R version.

so jaspBase will fail to compile on Windows with R4.4.0+ . but this PR will not resolve it.