### PR TITLE
Automatically call optionContainsValue for elements <>.types

### DIFF
--- a/R/common.R
+++ b/R/common.R
@@ -114,6 +114,9 @@ runJaspResults <- function(name, title, dataKey, options, stateKey, functionCall
   # ensure an analysis always starts with a clean hashtable of computed jasp Objects
   emptyRecomputed()
 
+  # hack to add types automatically as dependencies, used in jaspObjectR$dependOn
+  options("__JASP__OPTIONS" = options)
+
   analysisResult <-
     tryCatch(
       expr=withCallingHandlers(expr=analysis(jaspResults=jaspResults, dataset=dataset, options=options), error=.addStackTrace),


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/2594 in general for all analyses.

I would revert https://github.com/jasp-stats/jaspDescriptives/commit/7dff69664279428f002e47e3106156701a3125ac, because that causes all plots to be needlessly recomputed whenever a user adds a variable.

I'm not sure if there ever is a need to _not_ do this.