### PR TITLE
remove callbackNative because we dont need it

### DIFF
--- a/R/common.R
+++ b/R/common.R
@@ -620,7 +620,6 @@ jaspResultsStrings <- function() {
     ".readDatasetToEndNative",
     ".readDataSetHeaderNative",
     ".readDataSetRequestedNative",
-    ".callbackNative",
     ".requestStateFileNameNative",
     ".baseCitation",
     ".ppi",


### PR DESCRIPTION
Did it in https://github.com/jasp-stats/jasp-desktop/pull/5671 but it is hardly relevant