### PR TITLE
fix blank page before plot while export img to pdf

### DIFF
--- a/R/common.R
+++ b/R/common.R
@@ -885,6 +885,7 @@ saveImage <- function(plotName, format, height, width)
           relativePath,
           width = insize[1],
           height = insize[2],
+          onefile = FALSE,
           bg = "transparent"
         )
 


### PR DESCRIPTION
Fix: https://github.com/jasp-stats/INTERNAL-jasp/issues/2782


Set `onefile=FALSE` : “generate a file with name containing the page number for each page”, see: https://stat.ethz.ch/R-manual/R-devel/library/grDevices/html/pdf.html ,So this needs to be discussed, I'm not sure if there are any other side effects of doing this